### PR TITLE
Add DropTable, DropView, DropIndex Operations

### DIFF
--- a/doc/vanilladb-sql.md
+++ b/doc/vanilladb-sql.md
@@ -63,7 +63,7 @@ Other restrictions:
 ```
 <UpdateCmd>         := <Insert> | <Delete> | <Modify> | <Create> | <Drop>
 <Create>            := <CreateTable> | <CreateView> | <CreateIndex>
-<Drop>              := <DropIndex>
+<Drop>              := <DropTable> | <DropView> | <DropIndex>
 <Insert>            := INSERT INTO IdTok ( <FieldList> )
                        VALUES ( <ConstantList> )
 <FieldList>         := <Field> [ , <Field> ]
@@ -74,10 +74,12 @@ Other restrictions:
 <ModifyExpression>  := <Expression> | <BinaryArithmeticExpression>
 <ModifyTermList>    := <Field> = <ModifyExpression> [ , <ModifyTermList> ]
 <CreateTable>       := CREATE TABLE IdTok ( <FieldDefs> )
+<DropTable>         := DROP TABLE IdTok
 <FieldDefs>         := <FieldDef> [ , <FieldDef> ]
 <FieldDef>          := IdTock <TypeDef>
 <TypeDef>           := INT | LONG | DOUBLE | VARCHAR ( NumericTok )
 <CreateView>        := CREATE VIEW IdTok AS <Query>
+<DropView>          := DROP VIEW IdTok
 <CreateIndex>       := CREATE INDEX IdTok ON IdTok ( <Field> )
 <DropIndex>         := DROP INDEX IdTok
 ```

--- a/doc/vanilladb-sql.md
+++ b/doc/vanilladb-sql.md
@@ -28,9 +28,9 @@ Other restrictions:
 <Field>         := IdTok
 <Constant>      := StrTok | NumericTok
 <Expression>    := <Field> | <Constant>
-<BinaryArithmeticExpression>	:=
+<BinaryArithmeticExpression>    :=
                                 ADD(<Expression>, <Expression>) |
-                        		SUB(<Expression>, <Expression>) |
+                                SUB(<Expression>, <Expression>) |
                                 MUL(<Expression>, <Expression>) |
                                 DIV(<Expression>, <Expression>)
 <Term>  :=
@@ -61,8 +61,9 @@ Other restrictions:
 ### Updates
 
 ```
-<UpdateCmd>         := <Insert> | <Delete> | <Modify> | <Create>
+<UpdateCmd>         := <Insert> | <Delete> | <Modify> | <Create> | <Drop>
 <Create>            := <CreateTable> | <CreateView> | <CreateIndex>
+<Drop>              := <DropIndex>
 <Insert>            := INSERT INTO IdTok ( <FieldList> )
                        VALUES ( <ConstantList> )
 <FieldList>         := <Field> [ , <Field> ]
@@ -78,4 +79,5 @@ Other restrictions:
 <TypeDef>           := INT | LONG | DOUBLE | VARCHAR ( NumericTok )
 <CreateView>        := CREATE VIEW IdTok AS <Query>
 <CreateIndex>       := CREATE INDEX IdTok ON IdTok ( <Field> )
+<DropIndex>         := DROP INDEX IdTok
 ```

--- a/src/main/java/org/vanilladb/core/query/parse/DropIndexData.java
+++ b/src/main/java/org/vanilladb/core/query/parse/DropIndexData.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright 2016 vanilladb.org
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package org.vanilladb.core.query.parse;
+
+/**
+ * The parser for the <em>drop index</em> statement.
+ */
+public class DropIndexData {
+	private String idxName;
+
+	/**
+	 * Saves the index type, table and field names of the specified index.
+	 * 
+	 * @param idxName
+	 *            the name of the index
+	 */
+	public DropIndexData(String idxName) {
+		this.idxName = idxName;
+	}
+
+	/**
+	 * Returns the name of the index.
+	 * 
+	 * @return the name of the index
+	 */
+	public String indexName() {
+		return idxName;
+	}
+}

--- a/src/main/java/org/vanilladb/core/query/parse/DropTableData.java
+++ b/src/main/java/org/vanilladb/core/query/parse/DropTableData.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright 2016 vanilladb.org
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package org.vanilladb.core.query.parse;
+
+import org.vanilladb.core.sql.Schema;
+
+/**
+ * Data for the SQL <em>drop table</em> statement.
+ */
+public class DropTableData {
+	private String tblName;
+
+	/**
+	 * Saves the table name and schema.
+	 * 
+	 * @param tblName
+	 *            the name of the new table
+	 */
+	public DropTableData(String tblName) {
+		this.tblName = tblName;
+	}
+
+	/**
+	 * Returns the name of the new table.
+	 * 
+	 * @return the name of the new table
+	 */
+	public String tableName() {
+		return tblName;
+	}
+}

--- a/src/main/java/org/vanilladb/core/query/parse/DropTableData.java
+++ b/src/main/java/org/vanilladb/core/query/parse/DropTableData.java
@@ -15,8 +15,6 @@
  ******************************************************************************/
 package org.vanilladb.core.query.parse;
 
-import org.vanilladb.core.sql.Schema;
-
 /**
  * Data for the SQL <em>drop table</em> statement.
  */

--- a/src/main/java/org/vanilladb/core/query/parse/DropViewData.java
+++ b/src/main/java/org/vanilladb/core/query/parse/DropViewData.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright 2016 vanilladb.org
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package org.vanilladb.core.query.parse;
+
+/**
+ * Data for the SQL <em>drop view</em> statement.
+ */
+public class DropViewData {
+	private String viewName;
+
+	/**
+	 * Saves the view name and its definition.
+	 * 
+	 * @param viewName
+	 *            the name of the new view
+	 */
+	public DropViewData(String viewName) {
+		this.viewName = viewName;
+	}
+
+	/**
+	 * Returns the name of the new view.
+	 * 
+	 * @return the name of the new view
+	 */
+	public String viewName() {
+		return viewName;
+	}
+}

--- a/src/main/java/org/vanilladb/core/query/parse/Lexer.java
+++ b/src/main/java/org/vanilladb/core/query/parse/Lexer.java
@@ -189,7 +189,7 @@ public class Lexer {
 
 	private void initKeywords() {
 		keywords = Arrays.asList("select", "from", "where", "and", "insert",
-				"into", "values", "delete", "update", "set", "create", "table",
+				"into", "values", "delete", "drop", "update", "set", "create", "table",
 				"int", "double", "varchar", "view", "as", "index", "on",
 				"long", "order", "by", "asc", "desc", "sum", "count", "avg",
 				"min", "max", "distinct", "group", "add", "sub", "mul", "div",

--- a/src/main/java/org/vanilladb/core/query/parse/Parser.java
+++ b/src/main/java/org/vanilladb/core/query/parse/Parser.java
@@ -412,6 +412,8 @@ public class Parser {
 			return modify();
 		else if (lex.matchKeyword("create"))
 			return create();
+		else if (lex.matchKeyword("drop"))
+			return drop();
 		else
 			throw new UnsupportedOperationException();
 	}
@@ -580,5 +582,23 @@ public class Parser {
 		lex.eatDelim(')');
 		return new CreateIndexData(idxname, tblname, fldname,
 				DEFAULT_INDEX_TYPE);
+	}
+
+	/*
+	 * Method for parsing various drop commands.
+	 */
+
+	private Object drop() {
+		lex.eatKeyword("drop");
+		if (lex.matchKeyword("index"))
+			return dropIndex();
+		else
+			throw new UnsupportedOperationException();
+	}
+
+	private DropIndexData dropIndex() {
+		lex.eatKeyword("index");
+		String idxname = lex.eatId();
+		return new DropIndexData(idxname);
 	}
 }

--- a/src/main/java/org/vanilladb/core/query/parse/Parser.java
+++ b/src/main/java/org/vanilladb/core/query/parse/Parser.java
@@ -592,10 +592,26 @@ public class Parser {
 
 	private Object drop() {
 		lex.eatKeyword("drop");
-		if (lex.matchKeyword("index"))
+		if (lex.matchKeyword("table"))
+			return dropTable();
+		else if (lex.matchKeyword("view"))
+			return dropView();
+		else if (lex.matchKeyword("index"))
 			return dropIndex();
 		else
 			throw new UnsupportedOperationException();
+	}
+
+	private DropTableData dropTable() {
+		lex.eatKeyword("table");
+		String tblname = lex.eatId();
+		return new DropTableData(tblname);
+	}
+
+	private DropViewData dropView() {
+		lex.eatKeyword("view");
+		String viewname = lex.eatId();
+		return new DropViewData(viewname);
 	}
 
 	private DropIndexData dropIndex() {

--- a/src/main/java/org/vanilladb/core/query/parse/Parser.java
+++ b/src/main/java/org/vanilladb/core/query/parse/Parser.java
@@ -515,8 +515,10 @@ public class Parser {
 			return createTable();
 		else if (lex.matchKeyword("view"))
 			return createView();
-		else
+		else if (lex.matchKeyword("index"))
 			return createIndex();
+		else
+			throw new UnsupportedOperationException();
 	}
 
 	private CreateTableData createTable() {

--- a/src/main/java/org/vanilladb/core/query/planner/BasicUpdatePlanner.java
+++ b/src/main/java/org/vanilladb/core/query/planner/BasicUpdatePlanner.java
@@ -25,8 +25,10 @@ import org.vanilladb.core.query.algebra.UpdateScan;
 import org.vanilladb.core.query.parse.CreateIndexData;
 import org.vanilladb.core.query.parse.CreateTableData;
 import org.vanilladb.core.query.parse.CreateViewData;
-import org.vanilladb.core.query.parse.DeleteData;
+import org.vanilladb.core.query.parse.DropTableData;
+import org.vanilladb.core.query.parse.DropViewData;
 import org.vanilladb.core.query.parse.DropIndexData;
+import org.vanilladb.core.query.parse.DeleteData;
 import org.vanilladb.core.query.parse.InsertData;
 import org.vanilladb.core.query.parse.ModifyData;
 import org.vanilladb.core.server.VanillaDb;
@@ -105,6 +107,18 @@ public class BasicUpdatePlanner implements UpdatePlanner {
 	public int executeCreateIndex(CreateIndexData data, Transaction tx) {
 		VanillaDb.catalogMgr().createIndex(data.indexName(), data.tableName(),
 				data.fieldName(), data.indexType(), tx);
+		return 0;
+	}
+
+	@Override
+	public int executeDropTable(DropTableData data, Transaction tx) {
+		VanillaDb.catalogMgr().dropTable(data.tableName(), tx);
+		return 0;
+	}
+
+	@Override
+	public int executeDropView(DropViewData data, Transaction tx) {
+		VanillaDb.catalogMgr().dropView(data.viewName(), tx);
 		return 0;
 	}
 

--- a/src/main/java/org/vanilladb/core/query/planner/BasicUpdatePlanner.java
+++ b/src/main/java/org/vanilladb/core/query/planner/BasicUpdatePlanner.java
@@ -26,6 +26,7 @@ import org.vanilladb.core.query.parse.CreateIndexData;
 import org.vanilladb.core.query.parse.CreateTableData;
 import org.vanilladb.core.query.parse.CreateViewData;
 import org.vanilladb.core.query.parse.DeleteData;
+import org.vanilladb.core.query.parse.DropIndexData;
 import org.vanilladb.core.query.parse.InsertData;
 import org.vanilladb.core.query.parse.ModifyData;
 import org.vanilladb.core.server.VanillaDb;
@@ -104,6 +105,12 @@ public class BasicUpdatePlanner implements UpdatePlanner {
 	public int executeCreateIndex(CreateIndexData data, Transaction tx) {
 		VanillaDb.catalogMgr().createIndex(data.indexName(), data.tableName(),
 				data.fieldName(), data.indexType(), tx);
+		return 0;
+	}
+
+	@Override
+	public int executeDropIndex(DropIndexData data, Transaction tx) {
+		VanillaDb.catalogMgr().dropIndex(data.indexName(), tx);
 		return 0;
 	}
 }

--- a/src/main/java/org/vanilladb/core/query/planner/Planner.java
+++ b/src/main/java/org/vanilladb/core/query/planner/Planner.java
@@ -20,6 +20,7 @@ import org.vanilladb.core.query.parse.CreateIndexData;
 import org.vanilladb.core.query.parse.CreateTableData;
 import org.vanilladb.core.query.parse.CreateViewData;
 import org.vanilladb.core.query.parse.DeleteData;
+import org.vanilladb.core.query.parse.DropIndexData;
 import org.vanilladb.core.query.parse.InsertData;
 import org.vanilladb.core.query.parse.ModifyData;
 import org.vanilladb.core.query.parse.Parser;
@@ -90,6 +91,9 @@ public class Planner {
 		} else if (obj.getClass().equals(CreateIndexData.class)) {
 			Verifier.verifyCreateIndexData((CreateIndexData) obj, tx);
 			return uPlanner.executeCreateIndex((CreateIndexData) obj, tx);
+		} else if (obj.getClass().equals(DropIndexData.class)) {
+			Verifier.verifyDropIndexData((DropIndexData) obj, tx);
+			return uPlanner.executeDropIndex((DropIndexData) obj, tx);
 		} else
 			throw new UnsupportedOperationException();
 	}

--- a/src/main/java/org/vanilladb/core/query/planner/Planner.java
+++ b/src/main/java/org/vanilladb/core/query/planner/Planner.java
@@ -19,8 +19,10 @@ import org.vanilladb.core.query.algebra.Plan;
 import org.vanilladb.core.query.parse.CreateIndexData;
 import org.vanilladb.core.query.parse.CreateTableData;
 import org.vanilladb.core.query.parse.CreateViewData;
-import org.vanilladb.core.query.parse.DeleteData;
+import org.vanilladb.core.query.parse.DropTableData;
+import org.vanilladb.core.query.parse.DropViewData;
 import org.vanilladb.core.query.parse.DropIndexData;
+import org.vanilladb.core.query.parse.DeleteData;
 import org.vanilladb.core.query.parse.InsertData;
 import org.vanilladb.core.query.parse.ModifyData;
 import org.vanilladb.core.query.parse.Parser;
@@ -91,6 +93,12 @@ public class Planner {
 		} else if (obj.getClass().equals(CreateIndexData.class)) {
 			Verifier.verifyCreateIndexData((CreateIndexData) obj, tx);
 			return uPlanner.executeCreateIndex((CreateIndexData) obj, tx);
+		} else if (obj.getClass().equals(DropTableData.class)) {
+			Verifier.verifyDropTableData((DropTableData) obj, tx);
+			return uPlanner.executeDropTable((DropTableData) obj, tx);
+		} else if (obj.getClass().equals(DropViewData.class)) {
+			Verifier.verifyDropViewData((DropViewData) obj, tx);
+			return uPlanner.executeDropView((DropViewData) obj, tx);
 		} else if (obj.getClass().equals(DropIndexData.class)) {
 			Verifier.verifyDropIndexData((DropIndexData) obj, tx);
 			return uPlanner.executeDropIndex((DropIndexData) obj, tx);

--- a/src/main/java/org/vanilladb/core/query/planner/UpdatePlanner.java
+++ b/src/main/java/org/vanilladb/core/query/planner/UpdatePlanner.java
@@ -18,8 +18,10 @@ package org.vanilladb.core.query.planner;
 import org.vanilladb.core.query.parse.CreateIndexData;
 import org.vanilladb.core.query.parse.CreateTableData;
 import org.vanilladb.core.query.parse.CreateViewData;
-import org.vanilladb.core.query.parse.DeleteData;
+import org.vanilladb.core.query.parse.DropTableData;
+import org.vanilladb.core.query.parse.DropViewData;
 import org.vanilladb.core.query.parse.DropIndexData;
+import org.vanilladb.core.query.parse.DeleteData;
 import org.vanilladb.core.query.parse.InsertData;
 import org.vanilladb.core.query.parse.ModifyData;
 import org.vanilladb.core.storage.tx.Transaction;
@@ -101,6 +103,30 @@ public interface UpdatePlanner {
 	 * @return the number of affected records
 	 */
 	int executeCreateIndex(CreateIndexData data, Transaction tx);
+
+	/**
+	 * Executes the specified drop table statement, and returns the number of
+	 * affected records.
+	 * 
+	 * @param data
+	 *            the parsed representation of the drop table statement
+	 * @param tx
+	 *            the calling transaction
+	 * @return the number of affected records
+	 */
+	int executeDropTable(DropTableData data, Transaction tx);
+
+	/**
+	 * Executes the specified drop view statement, and returns the number of
+	 * affected records.
+	 * 
+	 * @param data
+	 *            the parsed representation of the drop view statement
+	 * @param tx
+	 *            the calling transaction
+	 * @return the number of affected records
+	 */
+	int executeDropView(DropViewData data, Transaction tx);
 
 	/**
 	 * Executes the specified drop index statement, and returns the number of

--- a/src/main/java/org/vanilladb/core/query/planner/UpdatePlanner.java
+++ b/src/main/java/org/vanilladb/core/query/planner/UpdatePlanner.java
@@ -19,6 +19,7 @@ import org.vanilladb.core.query.parse.CreateIndexData;
 import org.vanilladb.core.query.parse.CreateTableData;
 import org.vanilladb.core.query.parse.CreateViewData;
 import org.vanilladb.core.query.parse.DeleteData;
+import org.vanilladb.core.query.parse.DropIndexData;
 import org.vanilladb.core.query.parse.InsertData;
 import org.vanilladb.core.query.parse.ModifyData;
 import org.vanilladb.core.storage.tx.Transaction;
@@ -100,4 +101,16 @@ public interface UpdatePlanner {
 	 * @return the number of affected records
 	 */
 	int executeCreateIndex(CreateIndexData data, Transaction tx);
+
+	/**
+	 * Executes the specified drop index statement, and returns the number of
+	 * affected records.
+	 * 
+	 * @param data
+	 *            the parsed representation of the drop index statement
+	 * @param tx
+	 *            the calling transaction
+	 * @return the number of affected records
+	 */
+	int executeDropIndex(DropIndexData data, Transaction tx);
 }

--- a/src/main/java/org/vanilladb/core/query/planner/Verifier.java
+++ b/src/main/java/org/vanilladb/core/query/planner/Verifier.java
@@ -226,6 +226,10 @@ public class Verifier {
 	}
 
 	public static void verifyDropIndexData(DropIndexData data, Transaction tx) {
+		// examine index name
+		if (VanillaDb.catalogMgr().getIndexInfoByName(data.indexName(), tx) == null)
+			throw new BadSemanticException("index " + data.indexName()
+					+ " does not exist");
 	}
 
 	public static void verifyCreateViewData(CreateViewData data, Transaction tx) {

--- a/src/main/java/org/vanilladb/core/query/planner/Verifier.java
+++ b/src/main/java/org/vanilladb/core/query/planner/Verifier.java
@@ -23,8 +23,10 @@ import java.util.Set;
 import org.vanilladb.core.query.parse.CreateIndexData;
 import org.vanilladb.core.query.parse.CreateTableData;
 import org.vanilladb.core.query.parse.CreateViewData;
-import org.vanilladb.core.query.parse.DeleteData;
+import org.vanilladb.core.query.parse.DropTableData;
+import org.vanilladb.core.query.parse.DropViewData;
 import org.vanilladb.core.query.parse.DropIndexData;
+import org.vanilladb.core.query.parse.DeleteData;
 import org.vanilladb.core.query.parse.InsertData;
 import org.vanilladb.core.query.parse.ModifyData;
 import org.vanilladb.core.query.parse.Parser;
@@ -191,6 +193,14 @@ public class Verifier {
 						+ fld + "' is too long; see the properties file ");
 	}
 
+	public static void verifyDropTableData(DropTableData data, Transaction tx) {
+		// examine table name
+		TableInfo ti = VanillaDb.catalogMgr().getTableInfo(data.tableName(), tx);
+		if (ti == null)
+			throw new BadSemanticException("table " + data.tableName()
+					+ " does not exist");
+	}
+
 	public static void verifyCreateIndexData(CreateIndexData data,
 			Transaction tx) {
 		// examine table name
@@ -215,8 +225,7 @@ public class Verifier {
 					+ " has already been indexed");
 	}
 
-	public static void verifyDropIndexData(DropIndexData data,
-			Transaction tx) {
+	public static void verifyDropIndexData(DropIndexData data, Transaction tx) {
 	}
 
 	public static void verifyCreateViewData(CreateViewData data, Transaction tx) {
@@ -226,6 +235,13 @@ public class Verifier {
 
 		// examine query data
 		verifyQueryData(data.viewDefData(), tx);
+	}
+
+	public static void verifyDropViewData(DropViewData data, Transaction tx) {
+		// examine view name
+		if (VanillaDb.catalogMgr().getViewDef(data.viewName(), tx) == null)
+			throw new BadSemanticException("view " + data.viewName()
+					+ " does not exist");
 	}
 
 	private static boolean matchFieldAndConstant(Schema sch, String field,

--- a/src/main/java/org/vanilladb/core/query/planner/Verifier.java
+++ b/src/main/java/org/vanilladb/core/query/planner/Verifier.java
@@ -24,6 +24,7 @@ import org.vanilladb.core.query.parse.CreateIndexData;
 import org.vanilladb.core.query.parse.CreateTableData;
 import org.vanilladb.core.query.parse.CreateViewData;
 import org.vanilladb.core.query.parse.DeleteData;
+import org.vanilladb.core.query.parse.DropIndexData;
 import org.vanilladb.core.query.parse.InsertData;
 import org.vanilladb.core.query.parse.ModifyData;
 import org.vanilladb.core.query.parse.Parser;
@@ -210,8 +211,12 @@ public class Verifier {
 		Map<String, IndexInfo> indexInfoes = VanillaDb.catalogMgr().getIndexInfo(
 				tableName, tx);
 		if (indexInfoes.containsKey(fieldName))
-			throw new BadSemanticException("field" + fieldName
+			throw new BadSemanticException("field " + fieldName
 					+ " has already been indexed");
+	}
+
+	public static void verifyDropIndexData(DropIndexData data,
+			Transaction tx) {
 	}
 
 	public static void verifyCreateViewData(CreateViewData data, Transaction tx) {

--- a/src/main/java/org/vanilladb/core/query/planner/index/IndexUpdatePlanner.java
+++ b/src/main/java/org/vanilladb/core/query/planner/index/IndexUpdatePlanner.java
@@ -29,6 +29,7 @@ import org.vanilladb.core.query.parse.CreateIndexData;
 import org.vanilladb.core.query.parse.CreateTableData;
 import org.vanilladb.core.query.parse.CreateViewData;
 import org.vanilladb.core.query.parse.DeleteData;
+import org.vanilladb.core.query.parse.DropIndexData;
 import org.vanilladb.core.query.parse.InsertData;
 import org.vanilladb.core.query.parse.ModifyData;
 import org.vanilladb.core.query.planner.UpdatePlanner;
@@ -218,6 +219,12 @@ public class IndexUpdatePlanner implements UpdatePlanner {
 	public int executeCreateIndex(CreateIndexData data, Transaction tx) {
 		VanillaDb.catalogMgr().createIndex(data.indexName(), data.tableName(),
 				data.fieldName(), data.indexType(), tx);
+		return 0;
+	}
+
+	@Override
+	public int executeDropIndex(DropIndexData data, Transaction tx) {
+		VanillaDb.catalogMgr().dropIndex(data.indexName(), tx);
 		return 0;
 	}
 }

--- a/src/main/java/org/vanilladb/core/query/planner/index/IndexUpdatePlanner.java
+++ b/src/main/java/org/vanilladb/core/query/planner/index/IndexUpdatePlanner.java
@@ -28,8 +28,10 @@ import org.vanilladb.core.query.algebra.index.IndexSelectPlan;
 import org.vanilladb.core.query.parse.CreateIndexData;
 import org.vanilladb.core.query.parse.CreateTableData;
 import org.vanilladb.core.query.parse.CreateViewData;
-import org.vanilladb.core.query.parse.DeleteData;
+import org.vanilladb.core.query.parse.DropTableData;
+import org.vanilladb.core.query.parse.DropViewData;
 import org.vanilladb.core.query.parse.DropIndexData;
+import org.vanilladb.core.query.parse.DeleteData;
 import org.vanilladb.core.query.parse.InsertData;
 import org.vanilladb.core.query.parse.ModifyData;
 import org.vanilladb.core.query.planner.UpdatePlanner;
@@ -219,6 +221,18 @@ public class IndexUpdatePlanner implements UpdatePlanner {
 	public int executeCreateIndex(CreateIndexData data, Transaction tx) {
 		VanillaDb.catalogMgr().createIndex(data.indexName(), data.tableName(),
 				data.fieldName(), data.indexType(), tx);
+		return 0;
+	}
+
+	@Override
+	public int executeDropTable(DropTableData data, Transaction tx) {
+		VanillaDb.catalogMgr().dropTable(data.tableName(), tx);
+		return 0;
+	}
+
+	@Override
+	public int executeDropView(DropViewData data, Transaction tx) {
+		VanillaDb.catalogMgr().dropView(data.viewName(), tx);
 		return 0;
 	}
 

--- a/src/main/java/org/vanilladb/core/storage/file/FileMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/file/FileMgr.java
@@ -303,12 +303,35 @@ public class FileMgr {
 						// Actually delete file
 						boolean hasDeleted = new File(logDirectory, fileName).delete();
 						if (!hasDeleted && logger.isLoggable(Level.WARNING))
-							logger.warning("cannot deleted old log file");
+							logger.warning("cannot delete old log file");
 					}
 				}
 		} catch (IOException e) {
 			if (logger.isLoggable(Level.WARNING))
 				logger.warning("there is something wrong when deleting log files");
+			e.printStackTrace();
+		}
+	}
+
+	/**
+	 * Delete the specified file.
+	 */
+	public void delete(String fileName) {
+		try {
+			synchronized (prepareAnchor(fileName)) {
+				// Close file, if it opened
+				IoChannel fileChannel = openFiles.remove(fileName);
+				if (fileChannel != null)
+					fileChannel.close();
+
+				// Actually delete file
+				boolean hasDeleted = new File(dbDirectory, fileName).delete();
+				if (!hasDeleted && logger.isLoggable(Level.WARNING))
+					logger.warning("cannot delete file: " + fileName);
+			}
+		} catch (IOException e) {
+			if (logger.isLoggable(Level.WARNING))
+				logger.warning("there is something wrong when deleting " + fileName);
 			e.printStackTrace();
 		}
 	}

--- a/src/main/java/org/vanilladb/core/storage/metadata/CatalogMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/metadata/CatalogMgr.java
@@ -18,6 +18,7 @@ package org.vanilladb.core.storage.metadata;
 import java.util.Map;
 
 import org.vanilladb.core.sql.Schema;
+import org.vanilladb.core.storage.index.Index;
 import org.vanilladb.core.storage.metadata.index.IndexInfo;
 import org.vanilladb.core.storage.metadata.index.IndexMgr;
 import org.vanilladb.core.storage.tx.Transaction;
@@ -68,5 +69,9 @@ public class CatalogMgr {
 
 	public Map<String, IndexInfo> getIndexInfo(String tblName, Transaction tx) {
 		return idxMgr.getIndexInfo(tblName, tx);
+	}
+
+	public IndexInfo getIndexInfoByName(String idxName, Transaction tx) {
+		return idxMgr.getIndexInfoByName(idxName, tx);
 	}
 }

--- a/src/main/java/org/vanilladb/core/storage/metadata/CatalogMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/metadata/CatalogMgr.java
@@ -54,6 +54,10 @@ public class CatalogMgr {
 		idxMgr.createIndex(idxName, tblName, fldName, indexType, tx);
 	}
 
+	public void dropIndex(String idxName, Transaction tx) {
+		idxMgr.dropIndex(idxName, tx);
+	}
+
 	public Map<String, IndexInfo> getIndexInfo(String tblName, Transaction tx) {
 		return idxMgr.getIndexInfo(tblName, tx);
 	}

--- a/src/main/java/org/vanilladb/core/storage/metadata/CatalogMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/metadata/CatalogMgr.java
@@ -37,12 +37,20 @@ public class CatalogMgr {
 		tblMgr.createTable(tblName, sch, tx);
 	}
 
+	public void dropTable(String tblName, Transaction tx) {
+		tblMgr.dropTable(tblName, tx);
+	}
+
 	public TableInfo getTableInfo(String tblName, Transaction tx) {
 		return tblMgr.getTableInfo(tblName, tx);
 	}
 
 	public void createView(String viewName, String viewDef, Transaction tx) {
 		viewMgr.createView(viewName, viewDef, tx);
+	}
+
+	public void dropView(String viewName, Transaction tx) {
+		viewMgr.dropView(viewName, tx);
 	}
 
 	public String getViewDef(String viewName, Transaction tx) {

--- a/src/main/java/org/vanilladb/core/storage/metadata/TableMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/metadata/TableMgr.java
@@ -146,8 +146,10 @@ public class TableMgr {
 	 *            the transaction creating the table
 	 */
 	public void dropTable(String tblName, Transaction tx) {
-		if (tblName != TCAT_TBLNAME && tblName != FCAT_TBLNAME)
-			formatFileHeader(tblName, tx);
+		// Remove the file
+		RecordFile rf = getTableInfo(tblName, tx).open(tx, true);
+		rf.remove();
+
 		// Optimization: remove from the TableInfo map
 		tiMap.remove(tblName);
 

--- a/src/main/java/org/vanilladb/core/storage/metadata/ViewMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/metadata/ViewMgr.java
@@ -62,6 +62,17 @@ class ViewMgr {
 		rf.close();
 	}
 
+	public void dropView(String vName, Transaction tx) {
+		TableInfo ti = tblMgr.getTableInfo(VCAT, tx);
+		RecordFile rf = ti.open(tx, true);
+		rf.beforeFirst();
+		while (rf.next()) {
+			if (rf.getVal(VCAT_VNAME).equals(new VarcharConstant(vName)))
+				rf.delete();
+		}
+		rf.close();
+	}
+
 	public String getViewDef(String vName, Transaction tx) {
 		String result = null;
 		TableInfo ti = tblMgr.getTableInfo(VCAT, tx);

--- a/src/main/java/org/vanilladb/core/storage/record/RecordFile.java
+++ b/src/main/java/org/vanilladb/core/storage/record/RecordFile.java
@@ -107,6 +107,14 @@ public class RecordFile implements Record {
 	}
 
 	/**
+	 * Remove the record file.
+	 */
+	public void remove() {
+		close();
+		VanillaDb.fileMgr().delete(fileName);
+	}
+
+	/**
 	 * Positions the current record so that a call to method next will wind up
 	 * at the first record.
 	 */

--- a/src/main/java/org/vanilladb/core/storage/record/RecordFile.java
+++ b/src/main/java/org/vanilladb/core/storage/record/RecordFile.java
@@ -108,6 +108,7 @@ public class RecordFile implements Record {
 
 	/**
 	 * Remove the record file.
+	 * TODO: handle the concurrency issues that might happen
 	 */
 	public void remove() {
 		close();


### PR DESCRIPTION
DropTable, DropView, and DropIndex operations are added and tested.

The function `verifyDropIndexData` in `Verifier.java` is empty, and I manage to throw the `BadSemanticException` in the function `dropIndex` in `IndexMgr.java` when the index does not exist, so that we don't have to search the index twice if the index exists. Please let me know if it is not okay.