### PR TITLE
Fix the problem caused by NullPointerException at newInstance(ConstantRange.java:52)

### DIFF
--- a/src/main/java/org/vanilladb/core/query/algebra/materialize/GroupByPlan.java
+++ b/src/main/java/org/vanilladb/core/query/algebra/materialize/GroupByPlan.java
@@ -99,25 +99,27 @@ public class GroupByPlan extends ReduceRecordsPlan {
 			for (AggregationFn aggFn : aggFns) {
 				String argFld = aggFn.argumentFieldName();
 				String fld = aggFn.fieldName();
+				Collection<Bucket> dist = hist.buckets(argFld);
+				if (dist.isEmpty())
+					continue;
 				if (aggFn.getClass().equals(SumFn.class))
 					gbHist.addBucket(fld,
-							sumBucket(hist.buckets(argFld), numGroups));
+							sumBucket(dist, numGroups));
 				else if (aggFn.getClass().equals(AvgFn.class))
 					gbHist.addBucket(fld,
-							avgBucket(hist.buckets(argFld), numGroups));
+							avgBucket(dist, numGroups));
 				else if (aggFn.getClass().equals(CountFn.class))
 					gbHist.addBucket(fld,
-							countBucket(hist.buckets(argFld), numGroups));
+							countBucket(dist, numGroups));
 				else if (aggFn.getClass().equals(DistinctCountFn.class))
-					gbHist.addBucket(
-							fld,
-							distinctCountBucket(hist.buckets(argFld), numGroups));
+					gbHist.addBucket(fld,
+							distinctCountBucket(dist, numGroups));
 				else if (aggFn.getClass().equals(MinFn.class))
 					gbHist.addBucket(fld,
-							minBucket(hist.buckets(argFld), numGroups));
+							minBucket(dist, numGroups));
 				else if (aggFn.getClass().equals(MaxFn.class))
 					gbHist.addBucket(fld,
-							maxBucket(hist.buckets(argFld), numGroups));
+							maxBucket(dist, numGroups));
 				else
 					throw new UnsupportedOperationException();
 			}


### PR DESCRIPTION
When `WHERE` and `GROUP BY` are used in the same query, the predicate can cause that there is no record in a group. For this reason (or maybe other unknown one), the `hist.buckets(argFld)` will return an empty `Collection<Bucket>`. `NullPointerException` will be consequently caused when the empty `Collection<Bucket>` are passed into functions, such as `avgBucket`, `maxBucket`, and `minBucket`.
`NullPointerException` as regards to the problem happens in the statement `Type type = low != null ? low.getType() : high.getType();` in `newInstance`, ConstantRange.java, while `low` and `high` are both `null`.
The modification prevents passing an empty `Collection<Bucket>` into those functions (`...Bucket`).