### PR TITLE
Fix the bug reported in issue #17

### DIFF
--- a/src/main/java/org/vanilladb/core/storage/index/btree/BTreeDir.java
+++ b/src/main/java/org/vanilladb/core/storage/index/btree/BTreeDir.java
@@ -47,9 +47,8 @@ public class BTreeDir {
 
 	private static final String FILENAME_POSTFIX = "_dir.idx";
 
-	public static void insertASlot(Transaction tx, String indexFileName, Type keyType, long blkNum, int slotId) {
+	public static void insertASlot(Transaction tx, BlockId blk, Type keyType, int slotId) {
 		// Open the specified directory
-		BlockId blk = new BlockId(indexFileName, blkNum);
 		BTreeDir dir = new BTreeDir(blk, keyType, tx);
 
 		// Insert the specified slot
@@ -59,9 +58,8 @@ public class BTreeDir {
 		dir.close();
 	}
 
-	public static void deleteASlot(Transaction tx, String indexFileName, Type keyType, long blkNum, int slotId) {
+	public static void deleteASlot(Transaction tx, BlockId blk, Type keyType, int slotId) {
 		// Open the specified directory
-		BlockId blk = new BlockId(indexFileName, blkNum);
 		BTreeDir dir = new BTreeDir(blk, keyType, tx);
 
 		// Delete the specified slot
@@ -368,8 +366,7 @@ public class BTreeDir {
 
 	private void insert(int slot, Constant val, long blkNum) {
 		// Insert an entry to the page
-		tx.recoveryMgr().logIndexPageInsertion(currentPage.currentBlk().fileName(), false, keyType,
-				currentPage.currentBlk().number(), slot);
+		tx.recoveryMgr().logIndexPageInsertion(currentPage.currentBlk(), false, keyType, slot);
 		currentPage.insert(slot);
 
 		currentPage.setVal(slot, SCH_KEY, val);

--- a/src/main/java/org/vanilladb/core/storage/index/btree/BTreeLeaf.java
+++ b/src/main/java/org/vanilladb/core/storage/index/btree/BTreeLeaf.java
@@ -58,10 +58,9 @@ public class BTreeLeaf {
 	
 	private static final String FILENAME_POSTFIX = "_leaf.idx";
 	
-	public static void insertASlot(Transaction tx, String indexFileName, Type keyType,
-			long blkNum, int slotId) {
+	public static void insertASlot(Transaction tx, BlockId blk, Type keyType, int slotId) {
 		// Open the specified leaf
-		BTreeLeaf dir = new BTreeLeaf(indexFileName, keyType, blkNum, tx);
+		BTreeLeaf dir = new BTreeLeaf(blk, keyType, tx);
 
 		// Insert the specified slot
 		dir.currentPage.insert(slotId);
@@ -70,10 +69,9 @@ public class BTreeLeaf {
 		dir.close();
 	}
 	
-	public static void deleteASlot(Transaction tx, String indexFileName, Type keyType,
-			long blkNum, int slotId) {
+	public static void deleteASlot(Transaction tx, BlockId blk, Type keyType, int slotId) {
 		// Open the specified leaf
-		BTreeLeaf dir = new BTreeLeaf(indexFileName, keyType, blkNum, tx);
+		BTreeLeaf dir = new BTreeLeaf(blk, keyType, tx);
 
 		// Delete the specified slot
 		dir.currentPage.delete(slotId);
@@ -180,14 +178,13 @@ public class BTreeLeaf {
 	 * @param blkNum
 	 * @param tx
 	 */
-	private BTreeLeaf(String indexFileName, Type keyType, long blkNum, Transaction tx) {
+	private BTreeLeaf(BlockId blk, Type keyType, Transaction tx) {
 		this.dataFileName = null;
 		this.schema = schema(keyType);
 		this.keyType = keyType;
 		this.searchRange = null;
 		this.tx = tx;
-		this.currentPage = new BTreePage(new BlockId(indexFileName, blkNum),
-				NUM_FLAGS, schema, tx);
+		this.currentPage = new BTreePage(blk, NUM_FLAGS, schema, tx);
 		ccMgr = tx.concurrencyMgr();
 	}
 
@@ -454,8 +451,7 @@ public class BTreeLeaf {
 	
 	private void insert(int slot, Constant val, RecordId rid) {
 		// Insert an entry to the page
-		tx.recoveryMgr().logIndexPageInsertion(currentPage.currentBlk().fileName(), false, keyType,
-				currentPage.currentBlk().number(), slot);
+		tx.recoveryMgr().logIndexPageInsertion(currentPage.currentBlk(), false, keyType, slot);
 		currentPage.insert(slot);
 		
 		currentPage.setVal(slot, SCH_KEY, val);
@@ -465,8 +461,7 @@ public class BTreeLeaf {
 	
 	private void delete(int slot) {
 		// Delete an entry of the page
-		tx.recoveryMgr().logIndexPageDeletion(currentPage.currentBlk().fileName(), false, keyType,
-				currentPage.currentBlk().number(), slot);
+		tx.recoveryMgr().logIndexPageDeletion(currentPage.currentBlk(), false, keyType, slot);
 		currentPage.delete(slot);
 	}
 }

--- a/src/main/java/org/vanilladb/core/storage/tx/recovery/IndexPageDeleteClr.java
+++ b/src/main/java/org/vanilladb/core/storage/tx/recovery/IndexPageDeleteClr.java
@@ -23,6 +23,7 @@ import org.vanilladb.core.sql.BigIntConstant;
 import org.vanilladb.core.sql.Constant;
 import org.vanilladb.core.sql.IntegerConstant;
 import org.vanilladb.core.sql.Type;
+import org.vanilladb.core.storage.file.BlockId;
 import org.vanilladb.core.storage.log.BasicLogRecord;
 import org.vanilladb.core.storage.log.LogSeqNum;
 import org.vanilladb.core.storage.tx.Transaction;
@@ -30,9 +31,9 @@ import org.vanilladb.core.storage.tx.Transaction;
 public class IndexPageDeleteClr extends IndexPageDeleteRecord implements CompesationLogRecord {
 	private LogSeqNum undoNextLSN;
 
-	public IndexPageDeleteClr(long txNum, String indexName, boolean isDirPage, Type keyType, long blkNum, int slotId,
-			LogSeqNum undoNextLSN) {
-		super(txNum, indexName, isDirPage, keyType, blkNum, slotId);
+	public IndexPageDeleteClr(long compTxNum, BlockId indexBlkId, boolean isDirPage,
+			Type keyType, int slotId, LogSeqNum undoNextLSN) {
+		super(compTxNum, indexBlkId, isDirPage, keyType, slotId);
 		this.undoNextLSN = undoNextLSN;
 
 	}

--- a/src/main/java/org/vanilladb/core/storage/tx/recovery/IndexPageDeleteRecord.java
+++ b/src/main/java/org/vanilladb/core/storage/tx/recovery/IndexPageDeleteRecord.java
@@ -37,31 +37,29 @@ import org.vanilladb.core.storage.log.LogSeqNum;
 import org.vanilladb.core.storage.tx.Transaction;
 
 public class IndexPageDeleteRecord implements LogRecord {
-	private long txNum, blkNum;
-	private String indexName;
+	private long txNum;
+	private BlockId indexBlkId;
 	private int slotId;
 	private boolean isDirPage;
 	private Type keyType;
 	private LogSeqNum lsn;
 
-	public IndexPageDeleteRecord(long txNum, String indexName,
-			boolean isDirPage, Type keyType, long blkNum, int slotId) {
+	public IndexPageDeleteRecord(long txNum, BlockId indexBlkId, boolean isDirPage,
+			Type keyType, int slotId) {
 		this.txNum = txNum;
-		this.indexName = indexName;
 		this.isDirPage = isDirPage;
 		this.keyType = keyType;
-		this.blkNum = blkNum;
+		this.indexBlkId = indexBlkId;
 		this.slotId = slotId;
-		this.lsn = null;
-
 	}
 
 	public IndexPageDeleteRecord(BasicLogRecord rec) {
 		txNum = (Long) rec.nextVal(BIGINT).asJavaVal();
-		indexName = (String) rec.nextVal(VARCHAR).asJavaVal();
 		isDirPage = (Integer) rec.nextVal(INTEGER).asJavaVal() == 1;
 		keyType = Type.newInstance((Integer) rec.nextVal(INTEGER).asJavaVal());
-		blkNum = (Long) rec.nextVal(BIGINT).asJavaVal();
+		String fileName = (String) rec.nextVal(VARCHAR).asJavaVal();
+		long blkNum = (Long) rec.nextVal(BIGINT).asJavaVal();
+		indexBlkId = new BlockId(fileName, blkNum);
 		slotId = (Integer) rec.nextVal(INTEGER).asJavaVal();
 		lsn = rec.getLSN();
 	}
@@ -93,26 +91,20 @@ public class IndexPageDeleteRecord implements LogRecord {
 		// repeat history
 		Buffer BlockBuff;
 		if (isDirPage) {
-			BlockId PageBlk = new BlockId(BTreeDir.getFileName(indexName),
-					blkNum);
-			BlockBuff = tx.bufferMgr().pin(PageBlk);
+			BlockBuff = tx.bufferMgr().pin(indexBlkId);
 
 			if (this.lsn.compareTo(BlockBuff.lastLsn()) == 1) {
-				BTreeDir.insertASlot(tx, indexName, keyType, blkNum, slotId);
+				BTreeDir.insertASlot(tx, indexBlkId, keyType, slotId);
 				LogSeqNum lsn = tx.recoveryMgr().logIndexPageInsertionClr(
-						this.txNum, indexName, isDirPage, keyType, blkNum,
-						slotId, this.lsn);
+						txNum, indexBlkId, isDirPage, keyType, slotId, this.lsn);
 				VanillaDb.logMgr().flush(lsn);
 			}
 		} else {
-			BlockId PageBlk = new BlockId(BTreeLeaf.getFileName(indexName),
-					blkNum);
-			BlockBuff = tx.bufferMgr().pin(PageBlk);
+			BlockBuff = tx.bufferMgr().pin(indexBlkId);
 			if (this.lsn.compareTo(BlockBuff.lastLsn()) == 1) {
-				BTreeLeaf.insertASlot(tx, indexName, keyType, blkNum, slotId);
+				BTreeLeaf.insertASlot(tx, indexBlkId, keyType, slotId);
 				LogSeqNum lsn = tx.recoveryMgr().logIndexPageInsertionClr(
-						this.txNum, indexName, isDirPage, keyType, blkNum,
-						slotId, this.lsn);
+						txNum, indexBlkId, isDirPage, keyType, slotId, this.lsn);
 				VanillaDb.logMgr().flush(lsn);
 			}
 		}
@@ -124,19 +116,15 @@ public class IndexPageDeleteRecord implements LogRecord {
 	public void redo(Transaction tx) {
 		Buffer BlockBuff;
 		if (isDirPage) {
-			BlockId PageBlk = new BlockId(BTreeDir.getFileName(indexName),
-					blkNum);
-			BlockBuff = tx.bufferMgr().pin(PageBlk);
+			BlockBuff = tx.bufferMgr().pin(indexBlkId);
 
 			if (this.lsn.compareTo(BlockBuff.lastLsn()) == 1) {
-				BTreeDir.deleteASlot(tx, indexName, keyType, blkNum, slotId);
+				BTreeDir.deleteASlot(tx, indexBlkId, keyType, slotId);
 			}
 		} else {
-			BlockId PageBlk = new BlockId(BTreeLeaf.getFileName(indexName),
-					blkNum);
-			BlockBuff = tx.bufferMgr().pin(PageBlk);
+			BlockBuff = tx.bufferMgr().pin(indexBlkId);
 			if (this.lsn.compareTo(BlockBuff.lastLsn()) == 1) {
-				BTreeLeaf.deleteASlot(tx, indexName, keyType, blkNum, slotId);
+				BTreeLeaf.deleteASlot(tx, indexBlkId, keyType, slotId);
 			}
 		}
 		tx.bufferMgr().unpin(BlockBuff);
@@ -144,8 +132,8 @@ public class IndexPageDeleteRecord implements LogRecord {
 
 	@Override
 	public String toString() {
-		return "<INDEX PAGE DELETE " + txNum + " " + indexName + " "
-				+ isDirPage + " " + keyType.getSqlType() + " " + blkNum + " "
+		return "<INDEX PAGE DELETE " + txNum + " " + isDirPage + " "
+				+ keyType.getSqlType() + " " + indexBlkId + " "
 				+ slotId + ">";
 	}
 
@@ -154,11 +142,11 @@ public class IndexPageDeleteRecord implements LogRecord {
 		List<Constant> rec = new LinkedList<Constant>();
 		rec.add(new IntegerConstant(op()));
 		rec.add(new BigIntConstant(txNum));
-		rec.add(new VarcharConstant(indexName));
 		// Covert Boolean into int
 		rec.add(new IntegerConstant(isDirPage ? 1 : 0));
 		rec.add(new IntegerConstant(keyType.getSqlType()));
-		rec.add(new BigIntConstant(blkNum));
+		rec.add(new VarcharConstant(indexBlkId.fileName()));
+		rec.add(new BigIntConstant(indexBlkId.number()));
 		rec.add(new IntegerConstant(slotId));
 		return rec;
 	}

--- a/src/main/java/org/vanilladb/core/storage/tx/recovery/IndexPageInsertClr.java
+++ b/src/main/java/org/vanilladb/core/storage/tx/recovery/IndexPageInsertClr.java
@@ -23,6 +23,7 @@ import org.vanilladb.core.sql.BigIntConstant;
 import org.vanilladb.core.sql.Constant;
 import org.vanilladb.core.sql.IntegerConstant;
 import org.vanilladb.core.sql.Type;
+import org.vanilladb.core.storage.file.BlockId;
 import org.vanilladb.core.storage.log.BasicLogRecord;
 import org.vanilladb.core.storage.log.LogSeqNum;
 import org.vanilladb.core.storage.tx.Transaction;
@@ -30,9 +31,9 @@ import org.vanilladb.core.storage.tx.Transaction;
 public class IndexPageInsertClr extends IndexPageInsertRecord implements CompesationLogRecord {
 	private LogSeqNum undoNextLSN;
 
-	public IndexPageInsertClr(long txNum, String indexName, boolean isDirPage, Type keyType, long blkNum, int slotId,
-			LogSeqNum undoNextLSN) {
-		super(txNum, indexName, isDirPage, keyType, blkNum, slotId);
+	public IndexPageInsertClr(long compTxNum, BlockId indexBlkId, boolean isDirPage,
+			Type keyType, int slotId, LogSeqNum undoNextLSN) {
+		super(compTxNum, indexBlkId, isDirPage, keyType, slotId);
 		this.undoNextLSN = undoNextLSN;
 
 	}

--- a/src/main/java/org/vanilladb/core/storage/tx/recovery/RecoveryMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/tx/recovery/RecoveryMgr.java
@@ -230,51 +230,49 @@ public class RecoveryMgr implements TransactionLifecycleListener {
 			return null;
 	}
 
-	public LogSeqNum logIndexPageInsertion(String indexName, boolean isDirPage,
-			Type keyType, long blkNum, int slotId) {
+	public LogSeqNum logIndexPageInsertion(BlockId indexBlkId, boolean isDirPage,
+			Type keyType, int slotId) {
 		if (enableLogging) {
-			return new IndexPageInsertRecord(txNum, indexName, isDirPage,
-					keyType, blkNum, slotId).writeToLog();
+			return new IndexPageInsertRecord(txNum, indexBlkId, isDirPage,
+					keyType, slotId).writeToLog();
 		} else
 			return null;
 	}
 
-	public LogSeqNum logIndexPageDeletion(String indexName, boolean isDirPage,
-			Type keyType, long blkNum, int slotId) {
+	public LogSeqNum logIndexPageDeletion(BlockId indexBlkId, boolean isDirPage,
+			Type keyType, int slotId) {
 		if (enableLogging) {
-			return new IndexPageDeleteRecord(txNum, indexName, isDirPage,
-					keyType, blkNum, slotId).writeToLog();
+			return new IndexPageDeleteRecord(txNum, indexBlkId, isDirPage,
+					keyType, slotId).writeToLog();
 		} else
 			return null;
 	}
 
-	public LogSeqNum logIndexPageInsertionClr(long txNum, String indexName,
-			boolean isDirPage, Type keyType, long blkNum, int slotId,
-			LogSeqNum undoNextLSN) {
+	public LogSeqNum logIndexPageInsertionClr(long compTxNum, BlockId indexBlkId, boolean isDirPage,
+			Type keyType, int slotId, LogSeqNum undoNextLSN) {
 		if (enableLogging) {
-			return new IndexPageInsertClr(txNum, indexName, isDirPage, keyType,
-					blkNum, slotId, undoNextLSN).writeToLog();
+			return new IndexPageInsertClr(compTxNum, indexBlkId, isDirPage,
+					keyType, slotId, undoNextLSN).writeToLog();
 		} else
 			return null;
 	}
 
-	public LogSeqNum logIndexPageDeletionClr(long txNum, String indexName,
-			boolean isDirPage, Type keyType, long blkNum, int slotId,
-			LogSeqNum undoNextLSN) {
+	public LogSeqNum logIndexPageDeletionClr(long compTxNum, BlockId indexBlkId, boolean isDirPage,
+			Type keyType, int slotId, LogSeqNum undoNextLSN) {
 		if (enableLogging) {
-			return new IndexPageDeleteClr(txNum, indexName, isDirPage, keyType,
-					blkNum, slotId, undoNextLSN).writeToLog();
+			return new IndexPageDeleteClr(compTxNum, indexBlkId, isDirPage,
+					keyType, slotId, undoNextLSN).writeToLog();
 		} else
 			return null;
 	}
 
-	public LogSeqNum logSetValClr(long txNum, Buffer buff, int offset,
+	public LogSeqNum logSetValClr(long compTxNum, Buffer buff, int offset,
 			Constant newVal, LogSeqNum undoNextLSN) {
 		if (enableLogging) {
 			BlockId blk = buff.block();
 			if (isTempBlock(blk))
 				return null;
-			return new SetValueClr(txNum, blk, offset, buff.getVal(offset,
+			return new SetValueClr(compTxNum, blk, offset, buff.getVal(offset,
 					newVal.getType()), newVal, undoNextLSN).writeToLog();
 		} else
 			return null;

--- a/src/main/java/org/vanilladb/core/storage/tx/recovery/SetValueClr.java
+++ b/src/main/java/org/vanilladb/core/storage/tx/recovery/SetValueClr.java
@@ -31,8 +31,8 @@ public class SetValueClr extends SetValueRecord implements CompesationLogRecord 
 
 	private LogSeqNum undoNextLSN;
 
-	public SetValueClr(long txNum, BlockId blk, int offset, Constant val, Constant newVal, LogSeqNum undoNextLSN) {
-		super(txNum, blk, offset, val, newVal);
+	public SetValueClr(long compTxNum, BlockId blk, int offset, Constant val, Constant newVal, LogSeqNum undoNextLSN) {
+		super(compTxNum, blk, offset, val, newVal);
 		this.undoNextLSN = undoNextLSN;
 	}
 


### PR DESCRIPTION
Fix the bug reported in issue #17 by making the logging APIs accept the block id (which includes a file name and a block number) instead of taking the index name as a parameter.