### PR TITLE
Avoid rolling back a tx twice

### DIFF
--- a/src/main/java/org/vanilladb/core/storage/index/btree/BTreeDir.java
+++ b/src/main/java/org/vanilladb/core/storage/index/btree/BTreeDir.java
@@ -222,111 +222,99 @@ public class BTreeDir {
 		// search from root to level 0
 		dirsMayBeUpdated = new ArrayList<BlockId>();
 		BlockId parentBlk = currentPage.currentBlk();
-		try {
-			ccMgr.crabDownDirBlockForModification(parentBlk);
-			long childBlkNum = findChildBlockNumber(searchKey);
-			BlockId childBlk;
-			dirsMayBeUpdated.add(parentBlk);
+		ccMgr.crabDownDirBlockForModification(parentBlk);
+		long childBlkNum = findChildBlockNumber(searchKey);
+		BlockId childBlk;
+		dirsMayBeUpdated.add(parentBlk);
 
-			// if it's not the lowest directory block
-			while (getLevelFlag(currentPage) > 0) {
-				// read child block
-				childBlk = new BlockId(currentPage.currentBlk().fileName(), childBlkNum);
-				ccMgr.crabDownDirBlockForModification(childBlk);
-				BTreePage child = new BTreePage(childBlk, NUM_FLAGS, schema, tx);
+		// if it's not the lowest directory block
+		while (getLevelFlag(currentPage) > 0) {
+			// read child block
+			childBlk = new BlockId(currentPage.currentBlk().fileName(), childBlkNum);
+			ccMgr.crabDownDirBlockForModification(childBlk);
+			BTreePage child = new BTreePage(childBlk, NUM_FLAGS, schema, tx);
 
-				// crabs back the parent if the child is not possible to split
-				if (!child.isGettingFull()) {
-					for (int i = dirsMayBeUpdated.size() - 1; i >= 0; i--)
-						ccMgr.crabBackDirBlockForModification(dirsMayBeUpdated.get(i));
-					dirsMayBeUpdated.clear();
-				}
-				dirsMayBeUpdated.add(childBlk);
-
-				// move current block to child block
-				currentPage.close();
-				currentPage = child;
-				childBlkNum = findChildBlockNumber(searchKey);
-				parentBlk = currentPage.currentBlk();
+			// crabs back the parent if the child is not possible to split
+			if (!child.isGettingFull()) {
+				for (int i = dirsMayBeUpdated.size() - 1; i >= 0; i--)
+					ccMgr.crabBackDirBlockForModification(dirsMayBeUpdated.get(i));
+				dirsMayBeUpdated.clear();
 			}
+			dirsMayBeUpdated.add(childBlk);
 
-			// get leaf block id
-			BlockId leafBlk = new BlockId(leafFileName, childBlkNum);
-			ccMgr.modifyLeafBlock(leafBlk); // exclusive lock
-			return leafBlk;
-		} catch (LockAbortException e) {
-			throw e;
+			// move current block to child block
+			currentPage.close();
+			currentPage = child;
+			childBlkNum = findChildBlockNumber(searchKey);
+			parentBlk = currentPage.currentBlk();
 		}
+
+		// get leaf block id
+		BlockId leafBlk = new BlockId(leafFileName, childBlkNum);
+		ccMgr.modifyLeafBlock(leafBlk); // exclusive lock
+		return leafBlk;
 	}
 
 	private BlockId searchForDelete(SearchKey searchKey, String leafFileName) {
 		// search from root to level 0
 		BlockId parentBlk = currentPage.currentBlk();
-		try {
-			ccMgr.crabDownDirBlockForRead(parentBlk);
-			long childBlkNum = findChildBlockNumber(searchKey);
-			BlockId childBlk;
+		ccMgr.crabDownDirBlockForRead(parentBlk);
+		long childBlkNum = findChildBlockNumber(searchKey);
+		BlockId childBlk;
 
-			// if it's not the lowest directory block
-			while (getLevelFlag(currentPage) > 0) {
-				// read child block
-				childBlk = new BlockId(currentPage.currentBlk().fileName(), childBlkNum);
-				ccMgr.crabDownDirBlockForRead(childBlk);
-				BTreePage child = new BTreePage(childBlk, NUM_FLAGS, schema, tx);
+		// if it's not the lowest directory block
+		while (getLevelFlag(currentPage) > 0) {
+			// read child block
+			childBlk = new BlockId(currentPage.currentBlk().fileName(), childBlkNum);
+			ccMgr.crabDownDirBlockForRead(childBlk);
+			BTreePage child = new BTreePage(childBlk, NUM_FLAGS, schema, tx);
 
-				// release parent block
-				ccMgr.crabBackDirBlockForRead(parentBlk);
-				currentPage.close();
+			// release parent block
+			ccMgr.crabBackDirBlockForRead(parentBlk);
+			currentPage.close();
 
-				// move current block to child block
-				currentPage = child;
-				childBlkNum = findChildBlockNumber(searchKey);
-				parentBlk = currentPage.currentBlk();
-			}
-
-			// get leaf block id
-			BlockId leafBlk = new BlockId(leafFileName, childBlkNum);
-			ccMgr.modifyLeafBlock(leafBlk); // exclusive lock
-			ccMgr.crabBackDirBlockForRead(currentPage.currentBlk());
-			return leafBlk;
-		} catch (LockAbortException e) {
-			throw e;
+			// move current block to child block
+			currentPage = child;
+			childBlkNum = findChildBlockNumber(searchKey);
+			parentBlk = currentPage.currentBlk();
 		}
+
+		// get leaf block id
+		BlockId leafBlk = new BlockId(leafFileName, childBlkNum);
+		ccMgr.modifyLeafBlock(leafBlk); // exclusive lock
+		ccMgr.crabBackDirBlockForRead(currentPage.currentBlk());
+		return leafBlk;
 	}
 
 	private BlockId searchForRead(SearchKey searchKey, String leafFileName) {
 		// search from root to level 0
 		BlockId parentBlk = currentPage.currentBlk();
-		try {
-			ccMgr.crabDownDirBlockForRead(parentBlk);
-			long childBlkNum = findChildBlockNumber(searchKey);
-			BlockId childBlk;
+		ccMgr.crabDownDirBlockForRead(parentBlk);
+		long childBlkNum = findChildBlockNumber(searchKey);
+		BlockId childBlk;
 
-			// if it's not the lowest directory block
-			while (getLevelFlag(currentPage) > 0) {
-				// read child block
-				childBlk = new BlockId(currentPage.currentBlk().fileName(), childBlkNum);
-				ccMgr.crabDownDirBlockForRead(childBlk);
-				BTreePage child = new BTreePage(childBlk, NUM_FLAGS, schema, tx);
+		// if it's not the lowest directory block
+		while (getLevelFlag(currentPage) > 0) {
+			// read child block
+			childBlk = new BlockId(currentPage.currentBlk().fileName(), childBlkNum);
+			ccMgr.crabDownDirBlockForRead(childBlk);
+			BTreePage child = new BTreePage(childBlk, NUM_FLAGS, schema, tx);
 
-				// release parent block
-				ccMgr.crabBackDirBlockForRead(parentBlk);
-				currentPage.close();
+			// release parent block
+			ccMgr.crabBackDirBlockForRead(parentBlk);
+			currentPage.close();
 
-				// move current block to child block
-				currentPage = child;
-				childBlkNum = findChildBlockNumber(searchKey);
-				parentBlk = currentPage.currentBlk();
-			}
-
-			// get leaf block id
-			BlockId leafBlk = new BlockId(leafFileName, childBlkNum);
-			ccMgr.readLeafBlock(leafBlk); // shared lock
-			ccMgr.crabBackDirBlockForRead(currentPage.currentBlk());
-			return leafBlk;
-		} catch (LockAbortException e) {
-			throw e;
+			// move current block to child block
+			currentPage = child;
+			childBlkNum = findChildBlockNumber(searchKey);
+			parentBlk = currentPage.currentBlk();
 		}
+
+		// get leaf block id
+		BlockId leafBlk = new BlockId(leafFileName, childBlkNum);
+		ccMgr.readLeafBlock(leafBlk); // shared lock
+		ccMgr.crabBackDirBlockForRead(currentPage.currentBlk());
+		return leafBlk;
 	}
 
 	private long findChildBlockNumber(SearchKey searchKey) {

--- a/src/main/java/org/vanilladb/core/storage/index/btree/BTreeDir.java
+++ b/src/main/java/org/vanilladb/core/storage/index/btree/BTreeDir.java
@@ -255,7 +255,6 @@ public class BTreeDir {
 			ccMgr.modifyLeafBlock(leafBlk); // exclusive lock
 			return leafBlk;
 		} catch (LockAbortException e) {
-			tx.rollback();
 			throw e;
 		}
 	}
@@ -291,7 +290,6 @@ public class BTreeDir {
 			ccMgr.crabBackDirBlockForRead(currentPage.currentBlk());
 			return leafBlk;
 		} catch (LockAbortException e) {
-			tx.rollback();
 			throw e;
 		}
 	}
@@ -327,7 +325,6 @@ public class BTreeDir {
 			ccMgr.crabBackDirBlockForRead(currentPage.currentBlk());
 			return leafBlk;
 		} catch (LockAbortException e) {
-			tx.rollback();
 			throw e;
 		}
 	}

--- a/src/main/java/org/vanilladb/core/storage/index/btree/BTreeIndex.java
+++ b/src/main/java/org/vanilladb/core/storage/index/btree/BTreeIndex.java
@@ -254,20 +254,12 @@ public class BTreeIndex extends Index {
 	}
 
 	private long fileSize(String fileName) {
-		try {
-			ccMgr.readFile(fileName);
-		} catch (LockAbortException e) {
-			throw e;
-		}
+		ccMgr.readFile(fileName);
 		return VanillaDb.fileMgr().size(fileName);
 	}
 
 	private BlockId appendBlock(String fileName, Schema sch, long[] flags) {
-		try {
-			ccMgr.modifyFile(fileName);
-		} catch (LockAbortException e) {
-			throw e;
-		}
+		ccMgr.modifyFile(fileName);
 		BTPageFormatter btpf = new BTPageFormatter(sch, flags);
 
 		Buffer buff = tx.bufferMgr().pinNew(fileName, btpf);

--- a/src/main/java/org/vanilladb/core/storage/index/btree/BTreeIndex.java
+++ b/src/main/java/org/vanilladb/core/storage/index/btree/BTreeIndex.java
@@ -257,7 +257,6 @@ public class BTreeIndex extends Index {
 		try {
 			ccMgr.readFile(fileName);
 		} catch (LockAbortException e) {
-			tx.rollback();
 			throw e;
 		}
 		return VanillaDb.fileMgr().size(fileName);
@@ -267,7 +266,6 @@ public class BTreeIndex extends Index {
 		try {
 			ccMgr.modifyFile(fileName);
 		} catch (LockAbortException e) {
-			tx.rollback();
 			throw e;
 		}
 		BTPageFormatter btpf = new BTPageFormatter(sch, flags);

--- a/src/main/java/org/vanilladb/core/storage/index/btree/BTreeLeaf.java
+++ b/src/main/java/org/vanilladb/core/storage/index/btree/BTreeLeaf.java
@@ -349,7 +349,6 @@ public class BTreeLeaf {
 				return new DirEntry(splitKey, newBlkNum);
 			}
 		} catch (LockAbortException e) {
-			tx.rollback();
 			throw e;
 		}
 	}
@@ -420,7 +419,6 @@ public class BTreeLeaf {
 				}
 			}
 		} catch (LockAbortException e) {
-			tx.rollback();
 			throw e;
 		}
 	}
@@ -478,7 +476,6 @@ public class BTreeLeaf {
 		try {
 			ccMgr.readLeafBlock(blk);
 		} catch (LockAbortException e) {
-			tx.rollback();
 			throw e;
 		}
 		currentPage.close();

--- a/src/main/java/org/vanilladb/core/storage/index/btree/BTreeLeaf.java
+++ b/src/main/java/org/vanilladb/core/storage/index/btree/BTreeLeaf.java
@@ -276,80 +276,76 @@ public class BTreeLeaf {
 	 *         no split
 	 */
 	public DirEntry insert(RecordId dataRecordId) {
-		try {
-			// search range must be a constant
-			if (!searchRange.isSingleValue())
-				throw new IllegalStateException();
-			
-			// ccMgr.modifyLeafBlock(currentPage.currentBlk());
-			currentSlot++;
-			SearchKey searchKey = searchRange.asSearchKey();
-			insert(currentSlot, searchKey, dataRecordId);
-			
+		// search range must be a constant
+		if (!searchRange.isSingleValue())
+			throw new IllegalStateException();
+		
+		// ccMgr.modifyLeafBlock(currentPage.currentBlk());
+		currentSlot++;
+		SearchKey searchKey = searchRange.asSearchKey();
+		insert(currentSlot, searchKey, dataRecordId);
+		
+		/*
+		 * If the inserted key is less than the key stored in the overflow
+		 * blocks, split this block to make sure that the key of the first
+		 * record in every block will be the same as the key of records in
+		 * the overflow blocks.
+		 */
+		if (currentSlot == 0 && getOverflowFlag(currentPage) != -1 &&
+				!getKey(currentPage, 1, keyType.length()).equals(searchKey)) {
+			SearchKey splitKey = getKey(currentPage, 1, keyType.length());
+			long newBlkNum = currentPage.split(1,
+					new long[] { getOverflowFlag(currentPage),
+							getSiblingFlag(currentPage) });
+			setOverflowFlag(currentPage, -1);
+			setSiblingFlag(currentPage, newBlkNum);
+			return new DirEntry(splitKey, newBlkNum);
+		}
+		
+		if (!currentPage.isFull())
+			return null;
+		
+		/*
+		 * If this block is full, then split the block and return the directory
+		 * entry of the new block.
+		 */
+		SearchKey firstKey = getKey(currentPage, 0, keyType.length());
+		SearchKey lastKey = getKey(currentPage, currentPage.getNumRecords() - 1,
+				keyType.length());
+		if (lastKey.equals(firstKey)) {
 			/*
-			 * If the inserted key is less than the key stored in the overflow
-			 * blocks, split this block to make sure that the key of the first
-			 * record in every block will be the same as the key of records in
-			 * the overflow blocks.
+			 * If all of the records in the page have the same key, then the
+			 * block does not split; instead, all but one of the records are
+			 * placed into an overflow block.
 			 */
-			if (currentSlot == 0 && getOverflowFlag(currentPage) != -1 &&
-					!getKey(currentPage, 1, keyType.length()).equals(searchKey)) {
-				SearchKey splitKey = getKey(currentPage, 1, keyType.length());
-				long newBlkNum = currentPage.split(1,
-						new long[] { getOverflowFlag(currentPage),
-								getSiblingFlag(currentPage) });
-				setOverflowFlag(currentPage, -1);
-				setSiblingFlag(currentPage, newBlkNum);
-				return new DirEntry(splitKey, newBlkNum);
-			}
+			long overflowFlag = (getOverflowFlag(currentPage) == -1) ?
+					currentPage.currentBlk().number() : getOverflowFlag(currentPage);
+			long newBlkNum = currentPage.split(1, new long[] { overflowFlag, -1 });
+			setOverflowFlag(currentPage, newBlkNum);
+			return null;
 			
-			if (!currentPage.isFull())
-				return null;
+		} else {
+			int splitPos = currentPage.getNumRecords() / 2;
+			SearchKey splitKey = getKey(currentPage, splitPos, keyType.length());
 			
-			/*
-			 * If this block is full, then split the block and return the directory
-			 * entry of the new block.
-			 */
-			SearchKey firstKey = getKey(currentPage, 0, keyType.length());
-			SearchKey lastKey = getKey(currentPage, currentPage.getNumRecords() - 1,
-					keyType.length());
-			if (lastKey.equals(firstKey)) {
-				/*
-				 * If all of the records in the page have the same key, then the
-				 * block does not split; instead, all but one of the records are
-				 * placed into an overflow block.
-				 */
-				long overflowFlag = (getOverflowFlag(currentPage) == -1) ?
-						currentPage.currentBlk().number() : getOverflowFlag(currentPage);
-				long newBlkNum = currentPage.split(1, new long[] { overflowFlag, -1 });
-				setOverflowFlag(currentPage, newBlkNum);
-				return null;
-				
+			// records having the same key must be in the same block
+			if (splitKey.equals(firstKey)) {
+				// move right, looking for a different key
+				while (getKey(currentPage, splitPos, keyType.length()).equals(splitKey))
+					splitPos++;
+				splitKey = getKey(currentPage, splitPos, keyType.length());
 			} else {
-				int splitPos = currentPage.getNumRecords() / 2;
-				SearchKey splitKey = getKey(currentPage, splitPos, keyType.length());
-				
-				// records having the same key must be in the same block
-				if (splitKey.equals(firstKey)) {
-					// move right, looking for a different key
-					while (getKey(currentPage, splitPos, keyType.length()).equals(splitKey))
-						splitPos++;
-					splitKey = getKey(currentPage, splitPos, keyType.length());
-				} else {
-					// move left, looking for first entry having that key
-					while (getKey(currentPage, splitPos - 1, keyType.length())
-							.equals(splitKey))
-						splitPos--;
-				}
-				
-				// split the block
-				long newBlkNum = currentPage.split(splitPos, new long[] { -1,
-						getSiblingFlag(currentPage) });
-				setSiblingFlag(currentPage, newBlkNum);
-				return new DirEntry(splitKey, newBlkNum);
+				// move left, looking for first entry having that key
+				while (getKey(currentPage, splitPos - 1, keyType.length())
+						.equals(splitKey))
+					splitPos--;
 			}
-		} catch (LockAbortException e) {
-			throw e;
+			
+			// split the block
+			long newBlkNum = currentPage.split(splitPos, new long[] { -1,
+					getSiblingFlag(currentPage) });
+			setSiblingFlag(currentPage, newBlkNum);
+			return new DirEntry(splitKey, newBlkNum);
 		}
 	}
 
@@ -362,64 +358,60 @@ public class BTreeLeaf {
 	 *            the data record ID whose record is to be deleted
 	 */
 	public void delete(RecordId dataRecordId) {
-		try {
-			// search range must be a constant
-			if (!searchRange.isSingleValue())
-				throw new IllegalStateException();
+		// search range must be a constant
+		if (!searchRange.isSingleValue())
+			throw new IllegalStateException();
 
-			// delete all entry with the specific key
-			while (next())
-				if (getDataRecordId().equals(dataRecordId)) {
-					// ccMgr.modifyLeafBlock(currentPage.currentBlk());
-					delete(currentSlot);
-					break;
-				}
+		// delete all entry with the specific key
+		while (next())
+			if (getDataRecordId().equals(dataRecordId)) {
+				// ccMgr.modifyLeafBlock(currentPage.currentBlk());
+				delete(currentSlot);
+				break;
+			}
 
-			if (!isOverflowing) {
-				/*
-				 * If the current regular block is empty or the key of the first
-				 * record is not equal to that of records in overflow blocks,
-				 * transfer one record from a overflow block to here (if any).
-				 */
-				if (getOverflowFlag(currentPage) != -1) {
-					// get overflow page
-					BlockId blk = new BlockId(currentPage.currentBlk().fileName(), getOverflowFlag(currentPage));
-					ccMgr.modifyLeafBlock(blk);
-					BTreePage overflowPage = new BTreePage(blk, NUM_FLAGS, schema, tx);
+		if (!isOverflowing) {
+			/*
+			 * If the current regular block is empty or the key of the first
+			 * record is not equal to that of records in overflow blocks,
+			 * transfer one record from a overflow block to here (if any).
+			 */
+			if (getOverflowFlag(currentPage) != -1) {
+				// get overflow page
+				BlockId blk = new BlockId(currentPage.currentBlk().fileName(), getOverflowFlag(currentPage));
+				ccMgr.modifyLeafBlock(blk);
+				BTreePage overflowPage = new BTreePage(blk, NUM_FLAGS, schema, tx);
 
-					SearchKey firstKey = getKey(currentPage, 0, keyType.length());
-					if ((currentPage.getNumRecords() == 0
-							|| (overflowPage.getNumRecords() != 0
-							&& getKey(overflowPage, 0, keyType.length()) != firstKey))) {
-						overflowPage.transferRecords(overflowPage.getNumRecords() - 1,
-								currentPage, 0, 1);
-						// if the overflow block is empty, make it a dead block
-						if (overflowPage.getNumRecords() == 0) {
-							long overflowFlag = (getOverflowFlag(overflowPage)
-									== currentPage.currentBlk().number())
-									? -1 : getOverflowFlag(overflowPage);
-							setOverflowFlag(currentPage, overflowFlag);
-						}
-						overflowPage.close();
+				SearchKey firstKey = getKey(currentPage, 0, keyType.length());
+				if ((currentPage.getNumRecords() == 0
+						|| (overflowPage.getNumRecords() != 0
+						&& getKey(overflowPage, 0, keyType.length()) != firstKey))) {
+					overflowPage.transferRecords(overflowPage.getNumRecords() - 1,
+							currentPage, 0, 1);
+					// if the overflow block is empty, make it a dead block
+					if (overflowPage.getNumRecords() == 0) {
+						long overflowFlag = (getOverflowFlag(overflowPage)
+								== currentPage.currentBlk().number())
+								? -1 : getOverflowFlag(overflowPage);
+						setOverflowFlag(currentPage, overflowFlag);
 					}
-				}
-			} else {
-				/*
-				 * If the current overflow block is empty, make it a dead block.
-				 */
-				if (currentPage.getNumRecords() == 0) {
-					// reset the overflow flag of original page
-					BlockId blk = new BlockId(currentPage.currentBlk().fileName(), moveFrom);
-					// ccMgr.modifyLeafBlock(blk);
-					BTreePage prePage = new BTreePage(blk, NUM_FLAGS, schema, tx);
-					long overflowFlag = (getOverflowFlag(currentPage) == prePage.currentBlk().number()) ? -1
-							: getOverflowFlag(currentPage);
-					setOverflowFlag(prePage, overflowFlag);
-					prePage.close();
+					overflowPage.close();
 				}
 			}
-		} catch (LockAbortException e) {
-			throw e;
+		} else {
+			/*
+			 * If the current overflow block is empty, make it a dead block.
+			 */
+			if (currentPage.getNumRecords() == 0) {
+				// reset the overflow flag of original page
+				BlockId blk = new BlockId(currentPage.currentBlk().fileName(), moveFrom);
+				// ccMgr.modifyLeafBlock(blk);
+				BTreePage prePage = new BTreePage(blk, NUM_FLAGS, schema, tx);
+				long overflowFlag = (getOverflowFlag(currentPage) == prePage.currentBlk().number()) ? -1
+						: getOverflowFlag(currentPage);
+				setOverflowFlag(prePage, overflowFlag);
+				prePage.close();
+			}
 		}
 	}
 	
@@ -473,11 +465,7 @@ public class BTreeLeaf {
 	private void moveTo(long blkNum, int slot) {
 		moveFrom = currentPage.currentBlk().number(); // for deletion
 		BlockId blk = new BlockId(currentPage.currentBlk().fileName(), blkNum);
-		try {
-			ccMgr.readLeafBlock(blk);
-		} catch (LockAbortException e) {
-			throw e;
-		}
+		ccMgr.readLeafBlock(blk);
 		currentPage.close();
 		currentPage = new BTreePage(blk, NUM_FLAGS, schema, tx);
 		currentSlot = slot;

--- a/src/main/java/org/vanilladb/core/storage/index/btree/BTreePage.java
+++ b/src/main/java/org/vanilladb/core/storage/index/btree/BTreePage.java
@@ -376,15 +376,11 @@ public class BTreePage {
 	}
 
 	private BlockId appendBlock(long[] flags) {
-		try {
-			tx.concurrencyMgr().modifyFile(blk.fileName());
-			BTPageFormatter btpf = new BTPageFormatter(schema, flags);
-			Buffer buff = tx.bufferMgr().pinNew(blk.fileName(), btpf);
-			tx.bufferMgr().unpin(buff);
-			return buff.block();
-		} catch (LockAbortException e) {
-			throw e;
-		}
+		tx.concurrencyMgr().modifyFile(blk.fileName());
+		BTPageFormatter btpf = new BTPageFormatter(schema, flags);
+		Buffer buff = tx.bufferMgr().pinNew(blk.fileName(), btpf);
+		tx.bufferMgr().unpin(buff);
+		return buff.block();
 	}
 
 	private void setVal(int offset, Constant val) {

--- a/src/main/java/org/vanilladb/core/storage/index/btree/BTreePage.java
+++ b/src/main/java/org/vanilladb/core/storage/index/btree/BTreePage.java
@@ -383,7 +383,6 @@ public class BTreePage {
 			tx.bufferMgr().unpin(buff);
 			return buff.block();
 		} catch (LockAbortException e) {
-			tx.rollback();
 			throw e;
 		}
 	}

--- a/src/main/java/org/vanilladb/core/storage/index/hash/HashIndex.java
+++ b/src/main/java/org/vanilladb/core/storage/index/hash/HashIndex.java
@@ -235,11 +235,7 @@ public class HashIndex extends Index {
 	}
 
 	private long fileSize(String fileName) {
-		try {
-			tx.concurrencyMgr().readFile(fileName);
-		} catch (LockAbortException e) {
-			throw e;
-		}
+		tx.concurrencyMgr().readFile(fileName);
 		return VanillaDb.fileMgr().size(fileName);
 	}
 	

--- a/src/main/java/org/vanilladb/core/storage/index/hash/HashIndex.java
+++ b/src/main/java/org/vanilladb/core/storage/index/hash/HashIndex.java
@@ -238,7 +238,6 @@ public class HashIndex extends Index {
 		try {
 			tx.concurrencyMgr().readFile(fileName);
 		} catch (LockAbortException e) {
-			tx.rollback();
 			throw e;
 		}
 		return VanillaDb.fileMgr().size(fileName);

--- a/src/main/java/org/vanilladb/core/storage/record/FileHeaderPage.java
+++ b/src/main/java/org/vanilladb/core/storage/record/FileHeaderPage.java
@@ -150,7 +150,6 @@ public class FileHeaderPage {
 			if (!isTempTable())
 				tx.concurrencyMgr().readBlock(blk);
 		} catch (LockAbortException e) {
-			tx.rollback();
 			throw e;
 		}
 		return currentBuff.getVal(offset, type);
@@ -163,7 +162,6 @@ public class FileHeaderPage {
 			if (!isTempTable())
 				tx.concurrencyMgr().modifyBlock(blk);
 		} catch (LockAbortException e) {
-			tx.rollback();
 			throw e;
 		}
 		LogSeqNum lsn = tx.recoveryMgr().logSetVal(currentBuff, offset, val);

--- a/src/main/java/org/vanilladb/core/storage/record/FileHeaderPage.java
+++ b/src/main/java/org/vanilladb/core/storage/record/FileHeaderPage.java
@@ -146,24 +146,16 @@ public class FileHeaderPage {
 	}
 
 	private Constant getVal(int offset, Type type) {
-		try {
-			if (!isTempTable())
-				tx.concurrencyMgr().readBlock(blk);
-		} catch (LockAbortException e) {
-			throw e;
-		}
+		if (!isTempTable())
+			tx.concurrencyMgr().readBlock(blk);
 		return currentBuff.getVal(offset, type);
 	}
 
 	private void setVal(int offset, Constant val) {
 		if (tx.isReadOnly() && !isTempTable())
 			throw new UnsupportedOperationException();
-		try {
-			if (!isTempTable())
-				tx.concurrencyMgr().modifyBlock(blk);
-		} catch (LockAbortException e) {
-			throw e;
-		}
+		if (!isTempTable())
+			tx.concurrencyMgr().modifyBlock(blk);
 		LogSeqNum lsn = tx.recoveryMgr().logSetVal(currentBuff, offset, val);
 		currentBuff.setVal(offset, val, tx.getTransactionNumber(), lsn);
 	}

--- a/src/main/java/org/vanilladb/core/storage/record/RecordFile.java
+++ b/src/main/java/org/vanilladb/core/storage/record/RecordFile.java
@@ -85,7 +85,6 @@ public class RecordFile implements Record {
 		try {
 			tx.concurrencyMgr().modifyFile(fileName);
 		} catch (LockAbortException e) {
-			tx.rollback();
 			throw e;
 		}
 		// header should be the first block of the given file
@@ -229,7 +228,6 @@ public class RecordFile implements Record {
 			if (!isTempTable())
 				tx.concurrencyMgr().modifyFile(fileName);
 		} catch (LockAbortException e) {
-			tx.rollback();
 			throw e;
 		}
 
@@ -291,7 +289,6 @@ public class RecordFile implements Record {
 			if (!isTempTable())
 				tx.concurrencyMgr().modifyFile(fileName);
 		} catch (LockAbortException e) {
-			tx.rollback();
 			throw e;
 		}
 
@@ -370,7 +367,6 @@ public class RecordFile implements Record {
 			if (!isTempTable())
 				tx.concurrencyMgr().readFile(fileName);
 		} catch (LockAbortException e) {
-			tx.rollback();
 			throw e;
 		}
 		return VanillaDb.fileMgr().size(fileName);
@@ -398,7 +394,6 @@ public class RecordFile implements Record {
 			if (!isTempTable())
 				tx.concurrencyMgr().insertBlock(buff.block());
 		} catch (LockAbortException e) {
-			tx.rollback();
 			throw e;
 		}
 
@@ -410,7 +405,6 @@ public class RecordFile implements Record {
 			if (!isTempTable())
 				tx.concurrencyMgr().lockRecordFileHeader(headerBlk);
 		} catch (LockAbortException e) {
-			tx.rollback();
 			throw e;
 		}
 		return new FileHeaderPage(fileName, tx);

--- a/src/main/java/org/vanilladb/core/storage/record/RecordFile.java
+++ b/src/main/java/org/vanilladb/core/storage/record/RecordFile.java
@@ -82,11 +82,7 @@ public class RecordFile implements Record {
 	 *            the transaction
 	 */
 	public static void formatFileHeader(String fileName, Transaction tx) {
-		try {
-			tx.concurrencyMgr().modifyFile(fileName);
-		} catch (LockAbortException e) {
-			throw e;
-		}
+		tx.concurrencyMgr().modifyFile(fileName);
 		// header should be the first block of the given file
 		if (VanillaDb.fileMgr().size(fileName) == 0) {
 			FileHeaderFormatter fhf = new FileHeaderFormatter();
@@ -224,12 +220,8 @@ public class RecordFile implements Record {
 
 		// Insertion may change the properties of this file,
 		// so that we need to lock the file.
-		try {
-			if (!isTempTable())
-				tx.concurrencyMgr().modifyFile(fileName);
-		} catch (LockAbortException e) {
-			throw e;
-		}
+		if (!isTempTable())
+			tx.concurrencyMgr().modifyFile(fileName);
 
 		// Modify the free chain which is start from a pointer in
 		// the header of the file.
@@ -285,12 +277,8 @@ public class RecordFile implements Record {
 
 		// Insertion may change the properties of this file,
 		// so that we need to lock the file.
-		try {
-			if (!isTempTable())
-				tx.concurrencyMgr().modifyFile(fileName);
-		} catch (LockAbortException e) {
-			throw e;
-		}
+		if (!isTempTable())
+			tx.concurrencyMgr().modifyFile(fileName);
 
 		// Open the header
 		if (fhp == null)
@@ -363,12 +351,8 @@ public class RecordFile implements Record {
 	 * @return the number of blocks in the file
 	 */
 	public long fileSize() {
-		try {
-			if (!isTempTable())
-				tx.concurrencyMgr().readFile(fileName);
-		} catch (LockAbortException e) {
-			throw e;
-		}
+		if (!isTempTable())
+			tx.concurrencyMgr().readFile(fileName);
 		return VanillaDb.fileMgr().size(fileName);
 	}
 
@@ -385,28 +369,20 @@ public class RecordFile implements Record {
 	}
 
 	private void appendBlock() {
-		try {
-			if (!isTempTable())
-				tx.concurrencyMgr().modifyFile(fileName);
-			RecordFormatter fmtr = new RecordFormatter(ti);
-			Buffer buff = tx.bufferMgr().pinNew(fileName, fmtr);
-			tx.bufferMgr().unpin(buff);
-			if (!isTempTable())
-				tx.concurrencyMgr().insertBlock(buff.block());
-		} catch (LockAbortException e) {
-			throw e;
-		}
+		if (!isTempTable())
+			tx.concurrencyMgr().modifyFile(fileName);
+		RecordFormatter fmtr = new RecordFormatter(ti);
+		Buffer buff = tx.bufferMgr().pinNew(fileName, fmtr);
+		tx.bufferMgr().unpin(buff);
+		if (!isTempTable())
+			tx.concurrencyMgr().insertBlock(buff.block());
 
 	}
 
 	private FileHeaderPage openHeaderForModification() {
 		// acquires exclusive access to the header
-		try {
-			if (!isTempTable())
-				tx.concurrencyMgr().lockRecordFileHeader(headerBlk);
-		} catch (LockAbortException e) {
-			throw e;
-		}
+		if (!isTempTable())
+			tx.concurrencyMgr().lockRecordFileHeader(headerBlk);
 		return new FileHeaderPage(fileName, tx);
 	}
 

--- a/src/main/java/org/vanilladb/core/storage/record/RecordPage.java
+++ b/src/main/java/org/vanilladb/core/storage/record/RecordPage.java
@@ -350,24 +350,16 @@ public class RecordPage implements Record {
 	}
 
 	private Constant getVal(int offset, Type type) {
-		try {
-			if (!isTempTable())
-				tx.concurrencyMgr().readRecord(new RecordId(blk, currentSlot));
-		} catch (LockAbortException e) {
-			throw e;
-		}
+		if (!isTempTable())
+			tx.concurrencyMgr().readRecord(new RecordId(blk, currentSlot));
 		return currentBuff.getVal(offset, type);
 	}
 
 	private void setVal(int offset, Constant val) {
 		if (tx.isReadOnly() && !isTempTable())
 			throw new UnsupportedOperationException();
-		try {
-			if (!isTempTable())
-				tx.concurrencyMgr().modifyRecord(new RecordId(blk, currentSlot));
-		} catch (LockAbortException e) {
-			throw e;
-		}
+		if (!isTempTable())
+			tx.concurrencyMgr().modifyRecord(new RecordId(blk, currentSlot));
 		LogSeqNum lsn = doLog ? tx.recoveryMgr().logSetVal(currentBuff, offset, val)
 				: null;
 		currentBuff.setVal(offset, val, tx.getTransactionNumber(), lsn);

--- a/src/main/java/org/vanilladb/core/storage/record/RecordPage.java
+++ b/src/main/java/org/vanilladb/core/storage/record/RecordPage.java
@@ -354,7 +354,6 @@ public class RecordPage implements Record {
 			if (!isTempTable())
 				tx.concurrencyMgr().readRecord(new RecordId(blk, currentSlot));
 		} catch (LockAbortException e) {
-			tx.rollback();
 			throw e;
 		}
 		return currentBuff.getVal(offset, type);
@@ -367,7 +366,6 @@ public class RecordPage implements Record {
 			if (!isTempTable())
 				tx.concurrencyMgr().modifyRecord(new RecordId(blk, currentSlot));
 		} catch (LockAbortException e) {
-			tx.rollback();
 			throw e;
 		}
 		LogSeqNum lsn = doLog ? tx.recoveryMgr().logSetVal(currentBuff, offset, val)


### PR DESCRIPTION
## Bug Description
When a transaction catches a `LockAbortException`, it is first rollbacked "locally", and then throw the exception. E.g.,
https://github.com/vanilladb/vanillacore/blob/793e3a32925e5525401ce411f1844dac44623a4a/src/main/java/org/vanilladb/core/storage/index/btree/BTreeDir.java#L257-L260

However, when the exception is thrown to the stored procedure level, the tx is rolled back again.

https://github.com/vanilladb/vanillabench/blob/d50ed403b43f04486cba9d4c152fba54969f867c/src/main/java/org/vanilladb/bench/server/procedure/BasicStoredProcedure.java#L42-L62

This behavior can be easily seen by setting the logging level to `FINE` and the following message will appear twice for each rolled back tx.

https://github.com/vanilladb/vanillacore/blob/793e3a32925e5525401ce411f1844dac44623a4a/src/main/java/org/vanilladb/core/storage/tx/Transaction.java#L108-L109
 
## Issue #24 and #30 
This pull request might fix both issues because if a tx is rolled back twice, each of its pinned buffers will be pinned once but unpinned twice. Eventually, this will violate the rule that the pin count of a buffer should not be negative and cause some bugs.

## Patch
All the local rollbacks are removed.

## JUnit Test
Results :

Tests run: 103, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 19:34 min 
[INFO] Finished at: 2018-01-03T22:43:15-05:00
[INFO] Final Memory: 18M/363M
[INFO] -----------------------------------------------------------------------