### PR TITLE
Fix a few bugs for logs and recovery

### DIFF
--- a/src/main/java/org/vanilladb/core/server/VanillaDb.java
+++ b/src/main/java/org/vanilladb/core/server/VanillaDb.java
@@ -143,8 +143,7 @@ public class VanillaDb {
 			if (logger.isLoggable(Level.INFO))
 				logger.info("recovering existing database");
 			// add a checkpoint record to limit rollback
-			RecoveryMgr.recover(initTx);
-			logMgr.removeAndCreateNewLog();
+			RecoveryMgr.initializeSystem(initTx);
 		}
 
 		// initialize the statistics manager to build the histogram

--- a/src/main/java/org/vanilladb/core/server/VanillaDb.java
+++ b/src/main/java/org/vanilladb/core/server/VanillaDb.java
@@ -138,7 +138,7 @@ public class VanillaDb {
 		initCatalogMgr(isDbNew, initTx);
 		if (isDbNew) {
 			if (logger.isLoggable(Level.INFO))
-				logger.info("creating new database");
+				logger.info("creating new database...");
 		} else {
 			if (logger.isLoggable(Level.INFO))
 				logger.info("recovering existing database");
@@ -148,6 +148,9 @@ public class VanillaDb {
 
 		// initialize the statistics manager to build the histogram
 		initStatMgr(initTx);
+		
+		// create a checkpoint
+		txMgr.createCheckpoint(initTx);
 
 		// commit the initializing transaction
 		initTx.commit();

--- a/src/main/java/org/vanilladb/core/storage/file/FileMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/file/FileMgr.java
@@ -106,15 +106,6 @@ public class FileMgr {
 		logDirectory = new File(LOG_FILES_DIR, dbName);
 		isNew = !dbDirectory.exists();
 
-		// deal with the log folder in a new database
-		if (isNew && !dbDirectory.equals(logDirectory)) {
-			// delete the old log file if db is new
-			if (logDirectory.exists()) {
-				deleteLogFiles();
-			} else if (!logDirectory.mkdir())
-				throw new RuntimeException("cannot create log file for" + dbName);
-		}
-
 		// check the existence of log folder
 		if (!isNew && !logDirectory.exists())
 			throw new RuntimeException("log file for the existed " + dbName + " is missing");
@@ -237,29 +228,6 @@ public class FileMgr {
 	}
 
 	/**
-	 * Deletes all old log files and builds new log files. XXX: This should not
-	 * be the business of FileMgr
-	 */
-	public void rebuildLogFile() {
-		try {
-			deleteLogFiles();
-
-			// Create a new log file
-			File logFile = new File(logDirectory, DEFAULT_LOG_FILE);
-			IoChannel fileChannel = IoAllocator.newIoChannel(logFile);
-			openFiles.put(DEFAULT_LOG_FILE, fileChannel);
-
-			// Create a new DD log file
-			logFile = new File(logDirectory, "vanilladddb.log");
-			fileChannel = IoAllocator.newIoChannel(logFile);
-			openFiles.put("vanilladddb.log", fileChannel);
-
-		} catch (IOException e) {
-			throw new RuntimeException("rebuild log file fail");
-		}
-	}
-
-	/**
 	 * Returns the file channel for the specified filename. The file channel is
 	 * stored in a map keyed on the filename. If the file is not open, then it
 	 * is opened and the file channel is added to the map.
@@ -287,33 +255,6 @@ public class FileMgr {
 	}
 
 	/**
-	 * Deletes all log files in the log directory. XXX: This should not be the
-	 * business of FileMgr
-	 */
-	private void deleteLogFiles() {
-		try {
-			for (String fileName : logDirectory.list())
-				if (fileName.endsWith(".log")) {
-					synchronized (prepareAnchor(fileName)) {
-						// Close file, if it opened
-						IoChannel fileChannel = openFiles.remove(fileName);
-						if (fileChannel != null)
-							fileChannel.close();
-
-						// Actually delete file
-						boolean hasDeleted = new File(logDirectory, fileName).delete();
-						if (!hasDeleted && logger.isLoggable(Level.WARNING))
-							logger.warning("cannot delete old log file");
-					}
-				}
-		} catch (IOException e) {
-			if (logger.isLoggable(Level.WARNING))
-				logger.warning("there is something wrong when deleting log files");
-			e.printStackTrace();
-		}
-	}
-
-	/**
 	 * Delete the specified file.
 	 * 
 	 * @param fileName
@@ -322,12 +263,12 @@ public class FileMgr {
 	public void delete(String fileName) {
 		try {
 			synchronized (prepareAnchor(fileName)) {
-				// Close file, if it opened
+				// Close file, if it was opened
 				IoChannel fileChannel = openFiles.remove(fileName);
 				if (fileChannel != null)
 					fileChannel.close();
 
-				// Actually delete file
+				// Delete the file
 				boolean hasDeleted = new File(dbDirectory, fileName).delete();
 				if (!hasDeleted && logger.isLoggable(Level.WARNING))
 					logger.warning("cannot delete file: " + fileName);

--- a/src/main/java/org/vanilladb/core/storage/log/LogMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/log/LogMgr.java
@@ -169,7 +169,13 @@ public class LogMgr implements Iterable<BasicLogRecord> {
 	public void removeAndCreateNewLog() {
 		logMgrLock.lock();
 		try {
-			VanillaDb.fileMgr().rebuildLogFile();
+			VanillaDb.fileMgr().delete(logFile);
+			
+			// Reset all the data
+			lastLsn = LogSeqNum.DEFAULT_VALUE;
+			lastFlushedLsn = LogSeqNum.DEFAULT_VALUE;
+			
+			// 'myPage', 'currentBlk' and 'currentPos' are reset in this method
 			appendNewBlock();
 		} finally {
 			logMgrLock.unlock();

--- a/src/main/java/org/vanilladb/core/storage/tx/recovery/LogReader.java
+++ b/src/main/java/org/vanilladb/core/storage/tx/recovery/LogReader.java
@@ -88,7 +88,7 @@ public class LogReader {
 	}
 
 	public String getLogString() {
-		System.out.println(currentRec.getLSN() + currentRec.toString());
+//		System.out.println(currentRec.getLSN() + currentRec.toString());
 		return currentRec.getLSN() + currentRec.toString();
 	}
 

--- a/src/main/java/org/vanilladb/core/storage/tx/recovery/RecoveryMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/tx/recovery/RecoveryMgr.java
@@ -61,10 +61,8 @@ public class RecoveryMgr implements TransactionLifecycleListener {
 		tx.bufferMgr().flushAll();
 		VanillaDb.logMgr().removeAndCreateNewLog();
 		
-		// Note that we add the records after the new log file is created
+		// Add a start record for this transaction
 		new StartRecord(tx.getTransactionNumber()).writeToLog();
-		LogSeqNum lsn = new CheckpointRecord().writeToLog();
-		VanillaDb.logMgr().flush(lsn);
 	}
 
 	public static void partialRecover(Transaction tx, int stepsInUndo) {

--- a/src/main/java/org/vanilladb/core/storage/tx/recovery/RecoveryMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/tx/recovery/RecoveryMgr.java
@@ -56,9 +56,13 @@ public class RecoveryMgr implements TransactionLifecycleListener {
 	 * @param tx
 	 *            the context of executing transaction
 	 */
-	public static void recover(Transaction tx) {
+	public static void initializeSystem(Transaction tx) {
 		tx.recoveryMgr().doRecover(tx);
 		tx.bufferMgr().flushAll();
+		VanillaDb.logMgr().removeAndCreateNewLog();
+		
+		// Note that we add the records after the new log file is created
+		new StartRecord(tx.getTransactionNumber()).writeToLog();
 		LogSeqNum lsn = new CheckpointRecord().writeToLog();
 		VanillaDb.logMgr().flush(lsn);
 	}

--- a/src/main/java/org/vanilladb/core/storage/tx/recovery/RecoveryMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/tx/recovery/RecoveryMgr.java
@@ -57,20 +57,12 @@ public class RecoveryMgr implements TransactionLifecycleListener {
 	 *            the context of executing transaction
 	 */
 	public static void initializeSystem(Transaction tx) {
-		tx.recoveryMgr().doRecover(tx);
+		tx.recoveryMgr().recoverSystem(tx);
 		tx.bufferMgr().flushAll();
 		VanillaDb.logMgr().removeAndCreateNewLog();
 		
 		// Add a start record for this transaction
 		new StartRecord(tx.getTransactionNumber()).writeToLog();
-	}
-
-	public static void partialRecover(Transaction tx, int stepsInUndo) {
-		tx.recoveryMgr().doPartialRecover(tx, stepsInUndo);
-	}
-
-	public static void partialRollback(Transaction tx, int stepsInUndo) {
-		tx.recoveryMgr().doPartialRollback(tx, stepsInUndo);
 	}
 
 	private Map<Long, LogSeqNum> txUnDoNextLSN = new HashMap<Long, LogSeqNum>();
@@ -113,7 +105,7 @@ public class RecoveryMgr implements TransactionLifecycleListener {
 	@Override
 	public void onTxRollback(Transaction tx) {
 		if (!tx.isReadOnly() && enableLogging) {
-			doRollback(tx);
+			rollback(tx);
 			LogSeqNum lsn = new RollbackRecord(txNum).writeToLog();
 			VanillaDb.logMgr().flush(lsn);
 		}
@@ -279,7 +271,7 @@ public class RecoveryMgr implements TransactionLifecycleListener {
 	 * calling {@link LogRecord#undo(Transaction)} for each log record it finds
 	 * for the transaction, until it finds the transaction's START record.
 	 */
-	private void doRollback(Transaction tx) {
+	void rollback(Transaction tx) {
 		ReversibleIterator<LogRecord> iter = new LogRecordIterator();
 		LogSeqNum txUnDoNextLSN = null;
 		while (iter.hasNext()) {
@@ -313,7 +305,7 @@ public class RecoveryMgr implements TransactionLifecycleListener {
 		}
 	}
 
-	private void doPartialRollback(Transaction tx, int stepsInUndo) {
+	void rollbackPartially(Transaction tx, int stepsInUndo) {
 		ReversibleIterator<LogRecord> iter = new LogRecordIterator();
 		LogSeqNum txUnDoNextLSN = null;
 		while (iter.hasNext() && stepsInUndo >= 0) {
@@ -350,7 +342,7 @@ public class RecoveryMgr implements TransactionLifecycleListener {
 	 * or when the end of the log is reached. The method then iterates backward
 	 * and redoes all finished transactions. TODO fix comments...
 	 */
-	private void doRecover(Transaction tx) {
+	void recoverSystem(Transaction tx) {
 		Set<Long> finishedTxs = new HashSet<Long>();
 		Set<Long> unCompletedTxs = new HashSet<Long>();
 
@@ -463,7 +455,7 @@ public class RecoveryMgr implements TransactionLifecycleListener {
 		}
 	}
 
-	private void doPartialRecover(Transaction tx, int stepsInUndo) {
+	void recoverSystemPartially(Transaction tx, int stepsInUndo) {
 		Set<Long> finishedTxs = new HashSet<Long>();
 		Set<Long> unCompletedTxs = new HashSet<Long>();
 

--- a/src/test/java/org/vanilladb/core/server/ServerInit.java
+++ b/src/test/java/org/vanilladb/core/server/ServerInit.java
@@ -229,7 +229,7 @@ public class ServerInit {
 			// add a checkpoint record to limit rollback
 			tx = VanillaDb.txMgr().newTransaction(
 					Connection.TRANSACTION_SERIALIZABLE, false);
-			RecoveryMgr.recover(tx);
+			RecoveryMgr.initializeSystem(tx);
 			tx.commit();
 			
 			// Set the flag indicating that the data is loaded

--- a/src/test/java/org/vanilladb/core/storage/tx/recovery/RecoveryBasicTest.java
+++ b/src/test/java/org/vanilladb/core/storage/tx/recovery/RecoveryBasicTest.java
@@ -194,7 +194,7 @@ public class RecoveryBasicTest {
 		}
 
 		Transaction recoveryTx = VanillaDb.txMgr().newTransaction(Connection.TRANSACTION_SERIALIZABLE, false);
-		RecoveryMgr.recover(recoveryTx);
+		RecoveryMgr.initializeSystem(recoveryTx);
 		// verify that tx1 and tx3 got rolled back
 		buff = recoveryTx.bufferMgr().pin(blk);
 		int ti = (Integer) buff.getVal(104, INTEGER).asJavaVal();
@@ -253,7 +253,7 @@ public class RecoveryBasicTest {
 
 		// Do total recovery again
 		Transaction recoveryTx = VanillaDb.txMgr().newTransaction(Connection.TRANSACTION_SERIALIZABLE, false);
-		RecoveryMgr.recover(recoveryTx);
+		RecoveryMgr.initializeSystem(recoveryTx);
 
 		// verify that tx1 and tx2 got rolled back
 		buff = recoveryTx.bufferMgr().pin(blk);
@@ -327,7 +327,7 @@ public class RecoveryBasicTest {
 		
 		// Do total recovery again
 		Transaction recoveryTx = VanillaDb.txMgr().newTransaction(Connection.TRANSACTION_SERIALIZABLE, false);
-		RecoveryMgr.recover(recoveryTx);
+		RecoveryMgr.initializeSystem(recoveryTx);
 
 		// verify that tx1 and tx2 got rolled back
 		buff = recoveryTx.bufferMgr().pin(blk);
@@ -401,7 +401,7 @@ public class RecoveryBasicTest {
 		}
 
 		Transaction recoveryTx = VanillaDb.txMgr().newTransaction(Connection.TRANSACTION_SERIALIZABLE, false);
-		RecoveryMgr.recover(recoveryTx);
+		RecoveryMgr.initializeSystem(recoveryTx);
 		Buffer buff = recoveryTx.bufferMgr().pin(blk);
 
 		int ti1 = (Integer) buff.getVal(204, INTEGER).asJavaVal();
@@ -503,7 +503,7 @@ public class RecoveryBasicTest {
 		
 		// The second tx does recovery (redo)
 		tx = VanillaDb.txMgr().newTransaction(Connection.TRANSACTION_SERIALIZABLE, false);
-		RecoveryMgr.recover(tx);
+		RecoveryMgr.initializeSystem(tx);
 		tx.commit();
 		
 		// The third tx checks the records

--- a/src/test/java/org/vanilladb/core/storage/tx/recovery/RecoveryBasicTest.java
+++ b/src/test/java/org/vanilladb/core/storage/tx/recovery/RecoveryBasicTest.java
@@ -249,11 +249,11 @@ public class RecoveryBasicTest {
 
 		// Do partial recovery to simulate crash druing recovery;
 		Transaction partRecoveryTx = VanillaDb.txMgr().newTransaction(Connection.TRANSACTION_SERIALIZABLE, false);
-		RecoveryMgr.partialRecover(partRecoveryTx, 5);
+		partRecoveryTx.recoveryMgr().recoverSystemPartially(partRecoveryTx, 5);
 
 		// Do total recovery again
 		Transaction recoveryTx = VanillaDb.txMgr().newTransaction(Connection.TRANSACTION_SERIALIZABLE, false);
-		RecoveryMgr.initializeSystem(recoveryTx);
+		recoveryTx.recoveryMgr().recoverSystem(recoveryTx);
 
 		// verify that tx1 and tx2 got rolled back
 		buff = recoveryTx.bufferMgr().pin(blk);
@@ -320,14 +320,12 @@ public class RecoveryBasicTest {
 		tx.bufferMgr().unpin(buff);
 
 		// Do partial recovery to simulate crash druing recovery;
-
-		RecoveryMgr.partialRollback(tx1, 5);
-	
-		RecoveryMgr.partialRollback(tx2, 5);
+		tx1.recoveryMgr().rollbackPartially(tx1, 5);
+		tx1.recoveryMgr().rollbackPartially(tx2, 5);
 		
 		// Do total recovery again
 		Transaction recoveryTx = VanillaDb.txMgr().newTransaction(Connection.TRANSACTION_SERIALIZABLE, false);
-		RecoveryMgr.initializeSystem(recoveryTx);
+		recoveryTx.recoveryMgr().recoverSystem(recoveryTx);
 
 		// verify that tx1 and tx2 got rolled back
 		buff = recoveryTx.bufferMgr().pin(blk);


### PR DESCRIPTION
This patch fixes the following bugs. These bugs all happen after the system firstly restarts from a crash.

1. The system created a dummy log file `vanilladddb.log`.
2. The system did not flush the log to the new log file.
3. Executing a SQL causes a `NullPointerException`.

To reproduce these bugs, you can start a Core server with a fresh database. Enter some commands to create a table and insert some records, then shut down the server. This will be considered a crash for VanillaCore. Restarting the server will lead the above bugs.