### PR TITLE
Implement index-locking to prevent phantom read due to updates

### DIFF
--- a/src/main/java/org/vanilladb/core/storage/index/btree/BTreeIndex.java
+++ b/src/main/java/org/vanilladb/core/storage/index/btree/BTreeIndex.java
@@ -231,8 +231,6 @@ public class BTreeIndex extends Index {
 			leaf.close();
 			leaf = null;
 		}
-		// release all locks on index structure
-		ccMgr.releaseIndexLocks();
 		dirsMayBeUpdated = null;
 	}
 

--- a/src/main/java/org/vanilladb/core/storage/tx/concurrency/ConcurrencyMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/tx/concurrency/ConcurrencyMgr.java
@@ -15,9 +15,6 @@
  ******************************************************************************/
 package org.vanilladb.core.storage.tx.concurrency;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.vanilladb.core.storage.file.BlockId;
 import org.vanilladb.core.storage.record.RecordId;
 import org.vanilladb.core.storage.tx.Transaction;
@@ -97,12 +94,6 @@ public abstract class ConcurrencyMgr implements TransactionLifecycleListener {
 	 */
 	public abstract void readRecord(RecordId recId);
 
-	/*
-	 * Methods for B-Tree index locking
-	 */
-	private List<BlockId> readIndexBlks = new ArrayList<BlockId>();
-	private List<BlockId> writenIndexBlks = new ArrayList<BlockId>();
-
 	/**
 	 * Sets lock on the data file for modifying its index.
 	 * 
@@ -125,10 +116,7 @@ public abstract class ConcurrencyMgr implements TransactionLifecycleListener {
 	 * @param blk
 	 *            the block id
 	 */
-	public void modifyLeafBlock(BlockId blk) {
-		lockTbl.xLock(blk, txNum);
-		writenIndexBlks.add(blk);
-	}
+	public abstract void modifyLeafBlock(BlockId blk);
 
 	/**
 	 * Sets lock on the leaf block for read.
@@ -136,10 +124,11 @@ public abstract class ConcurrencyMgr implements TransactionLifecycleListener {
 	 * @param blk
 	 *            the block id
 	 */
-	public void readLeafBlock(BlockId blk) {
-		lockTbl.sLock(blk, txNum);
-		readIndexBlks.add(blk);
-	}
+	public abstract void readLeafBlock(BlockId blk);
+	
+	// =========================================================
+	// The following methods are designed for early lock release
+	// =========================================================
 
 	/**
 	 * Sets exclusive lock on the directory block when crabbing down for
@@ -150,7 +139,6 @@ public abstract class ConcurrencyMgr implements TransactionLifecycleListener {
 	 */
 	public void crabDownDirBlockForModification(BlockId blk) {
 		lockTbl.xLock(blk, txNum);
-		writenIndexBlks.add(blk);
 	}
 
 	/**
@@ -161,7 +149,6 @@ public abstract class ConcurrencyMgr implements TransactionLifecycleListener {
 	 */
 	public void crabDownDirBlockForRead(BlockId blk) {
 		lockTbl.sLock(blk, txNum);
-		readIndexBlks.add(blk);
 	}
 
 	/**
@@ -182,15 +169,6 @@ public abstract class ConcurrencyMgr implements TransactionLifecycleListener {
 	 */
 	public void crabBackDirBlockForRead(BlockId blk) {
 		lockTbl.release(blk, txNum, LockTable.S_LOCK);
-	}
-
-	public void releaseIndexLocks() {
-		for (BlockId blk : readIndexBlks)
-			lockTbl.release(blk, txNum, LockTable.S_LOCK);
-		for (BlockId blk : writenIndexBlks)
-			lockTbl.release(blk, txNum, LockTable.X_LOCK);
-		readIndexBlks.clear();
-		writenIndexBlks.clear();
 	}
 
 	public void lockRecordFileHeader(BlockId blk) {

--- a/src/main/java/org/vanilladb/core/storage/tx/concurrency/ReadCommittedConcurrencyMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/tx/concurrency/ReadCommittedConcurrencyMgr.java
@@ -120,7 +120,5 @@ public class ReadCommittedConcurrencyMgr extends ConcurrencyMgr {
 	@Override
 	public void readLeafBlock(BlockId blk) {
 		lockTbl.sLock(blk, txNum);
-		// releases S lock to allow phantoms
-		lockTbl.release(blk, txNum, LockTable.S_LOCK);
 	}
 }

--- a/src/main/java/org/vanilladb/core/storage/tx/concurrency/ReadCommittedConcurrencyMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/tx/concurrency/ReadCommittedConcurrencyMgr.java
@@ -111,4 +111,16 @@ public class ReadCommittedConcurrencyMgr extends ConcurrencyMgr {
 		// releases IS lock to allow phantoms
 		lockTbl.release(dataFileName, txNum, LockTable.IS_LOCK);
 	}
+	
+	@Override
+	public void modifyLeafBlock(BlockId blk) {
+		lockTbl.xLock(blk, txNum);
+	}
+	
+	@Override
+	public void readLeafBlock(BlockId blk) {
+		lockTbl.sLock(blk, txNum);
+		// releases S lock to allow phantoms
+		lockTbl.release(blk, txNum, LockTable.S_LOCK);
+	}
 }

--- a/src/main/java/org/vanilladb/core/storage/tx/concurrency/RepeatableReadConcurrencyMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/tx/concurrency/RepeatableReadConcurrencyMgr.java
@@ -15,11 +15,16 @@
  ******************************************************************************/
 package org.vanilladb.core.storage.tx.concurrency;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.vanilladb.core.storage.file.BlockId;
 import org.vanilladb.core.storage.record.RecordId;
 import org.vanilladb.core.storage.tx.Transaction;
 
 public class RepeatableReadConcurrencyMgr extends ConcurrencyMgr {
+	
+	private List<BlockId> readLeafBlks = new ArrayList<BlockId>();
 
 	public RepeatableReadConcurrencyMgr(long txNumber) {
 		txNum = txNumber;
@@ -37,7 +42,10 @@ public class RepeatableReadConcurrencyMgr extends ConcurrencyMgr {
 
 	@Override
 	public void onTxEndStatement(Transaction tx) {
-		// TODO allow phantoms
+		// releases S lock of indices to allow phantoms
+		for (BlockId blk : readLeafBlks)
+			lockTbl.release(blk, txNum, LockTable.S_LOCK);
+		readLeafBlks.clear();
 	}
 
 	@Override
@@ -112,7 +120,6 @@ public class RepeatableReadConcurrencyMgr extends ConcurrencyMgr {
 	@Override
 	public void readLeafBlock(BlockId blk) {
 		lockTbl.sLock(blk, txNum);
-		// releases S lock to allow phantoms
-		lockTbl.release(blk, txNum, LockTable.S_LOCK);
+		readLeafBlks.add(blk);
 	}
 }

--- a/src/main/java/org/vanilladb/core/storage/tx/concurrency/RepeatableReadConcurrencyMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/tx/concurrency/RepeatableReadConcurrencyMgr.java
@@ -103,4 +103,16 @@ public class RepeatableReadConcurrencyMgr extends ConcurrencyMgr {
 		// release IS lock to allow phantoms
 		lockTbl.release(dataFileName, txNum, LockTable.IS_LOCK);
 	}
+	
+	@Override
+	public void modifyLeafBlock(BlockId blk) {
+		lockTbl.xLock(blk, txNum);
+	}
+	
+	@Override
+	public void readLeafBlock(BlockId blk) {
+		lockTbl.sLock(blk, txNum);
+		// releases S lock to allow phantoms
+		lockTbl.release(blk, txNum, LockTable.S_LOCK);
+	}
 }

--- a/src/main/java/org/vanilladb/core/storage/tx/concurrency/SerializableConcurrencyMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/tx/concurrency/SerializableConcurrencyMgr.java
@@ -91,4 +91,14 @@ public class SerializableConcurrencyMgr extends ConcurrencyMgr {
 	public void readIndex(String dataFileName) {
 		lockTbl.isLock(dataFileName, txNum);
 	}
+	
+	@Override
+	public void modifyLeafBlock(BlockId blk) {
+		lockTbl.xLock(blk, txNum);
+	}
+	
+	@Override
+	public void readLeafBlock(BlockId blk) {
+		lockTbl.sLock(blk, txNum);
+	}
 }

--- a/src/test/java/org/vanilladb/core/FullTestSuite.java
+++ b/src/test/java/org/vanilladb/core/FullTestSuite.java
@@ -21,6 +21,7 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite.SuiteClasses;
 import org.vanilladb.core.IsolatedClassLoaderSuite.IsolationRoot;
+import org.vanilladb.core.integration.PhantomTest;
 import org.vanilladb.core.server.ServerInit;
 import org.vanilladb.core.server.VanillaDb;
 import org.vanilladb.core.storage.file.FileMgr;
@@ -30,6 +31,9 @@ import org.vanilladb.core.storage.file.FileMgr;
 	StorageTestSuite.class,
 	
 	QueryTestSuite.class,
+	
+	// Integration Tests
+	PhantomTest.class
 })
 @IsolationRoot(VanillaDb.class)
 public class FullTestSuite {

--- a/src/test/java/org/vanilladb/core/integrated/PhantomTest.java
+++ b/src/test/java/org/vanilladb/core/integrated/PhantomTest.java
@@ -1,0 +1,189 @@
+package org.vanilladb.core.integrated;
+
+import java.sql.Connection;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.vanilladb.core.query.algebra.Plan;
+import org.vanilladb.core.query.algebra.Scan;
+import org.vanilladb.core.query.planner.Planner;
+import org.vanilladb.core.server.ServerInit;
+import org.vanilladb.core.server.VanillaDb;
+import org.vanilladb.core.sql.Constant;
+import org.vanilladb.core.storage.buffer.BufferConcurrencyTest;
+import org.vanilladb.core.storage.tx.Transaction;
+import org.vanilladb.core.storage.tx.TransactionMgr;
+import org.vanilladb.core.storage.tx.concurrency.LockAbortException;
+
+public class PhantomTest {
+private static Logger logger = Logger.getLogger(BufferConcurrencyTest.class.getName());
+	
+	@BeforeClass
+	public static void init() {
+		ServerInit.init(PhantomTest.class);
+		loadTestbed();
+		
+		if (logger.isLoggable(Level.INFO))
+			logger.info("BEGIN PHANTOM TEST");
+	}
+	
+	@AfterClass
+	public static void finish() {
+		if (logger.isLoggable(Level.INFO))
+			logger.info("FINISH PHANTOM TEST");
+	}
+	
+	private static void loadTestbed() {
+		Transaction tx = VanillaDb.txMgr().newTransaction(
+				Connection.TRANSACTION_SERIALIZABLE, false);
+		Planner planner = VanillaDb.newPlanner();
+		
+		// Create a table
+		planner.executeUpdate("CREATE TABLE test (age INT, score INT)", tx);
+		
+		// Create a B-Tree index
+		planner.executeUpdate("CREATE INDEX age_idx ON test (age) USING BTREE", tx);
+		
+		// Insert a few record
+		planner.executeUpdate("INSERT INTO test (age, score) VALUES (18, 80)", tx);
+		planner.executeUpdate("INSERT INTO test (age, score) VALUES (20, 65)", tx);
+		planner.executeUpdate("INSERT INTO test (age, score) VALUES (23, 95)", tx);
+		
+		tx.commit();
+		
+		if (logger.isLoggable(Level.INFO))
+			logger.info("TESTING DATA CREATED");
+	}
+	
+	@Test
+	public void testPhantomRead() {
+		CyclicBarrier barrier = new CyclicBarrier(3);
+		TransactionMgr txMgr = VanillaDb.txMgr();
+		Tx1Client tx1 = new Tx1Client(txMgr.newTransaction(
+				Connection.TRANSACTION_SERIALIZABLE, true), barrier);
+		Tx2Client tx2 = new Tx2Client(txMgr.newTransaction(
+				Connection.TRANSACTION_SERIALIZABLE, false), barrier);
+		
+		// Start running
+		tx1.start();
+		tx2.start();
+		
+		try {
+			// Phase 1: Tx 1 check max score
+			barrier.await();
+			// Phase 2: Tx 2 insert a record which alters the max score
+			barrier.await();
+			// Phase 3: Tx 1 check max score again
+			barrier.await();
+			
+			// Wait for finishing
+			tx1.join();
+			tx2.join();
+			
+			// Ensure no exception happens
+			Assert.assertTrue("Tx 1 throws an Exception", tx1.isSuccess());
+			Assert.assertTrue("Tx 2 throws an Exception", tx2.isSuccess());
+			
+			// Check the result
+			Assert.assertTrue("Phantom read happens", tx1.isSame());
+			
+		} catch (InterruptedException | BrokenBarrierException e) {
+			e.printStackTrace();
+		}
+		
+		
+	}
+	
+	private static class TxClient extends Thread {
+		protected Transaction tx;
+		private CyclicBarrier barrier;
+		private boolean success;
+		
+		public TxClient(Transaction tx, CyclicBarrier barrier) {
+			this.tx = tx;
+			this.barrier = barrier;
+		}
+
+		@Override
+		public void run() {
+			try {
+				barrier.await();
+				phase1();
+				barrier.await();
+				phase2();
+				barrier.await();
+				phase3();
+				
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+			success = true;
+		}
+		
+		public void phase1() { };
+		public void phase2() { };
+		public void phase3() { };
+		
+		public boolean isSuccess() { return success; }
+	}
+	
+	private static class Tx1Client extends TxClient {
+		private Constant maxScore;
+		private boolean isSame;
+
+		public Tx1Client(Transaction tx, CyclicBarrier barrier) {
+			super(tx, barrier);
+		}
+		
+		@Override
+		public void phase1() {
+			maxScore = queryMaxScore();
+			tx.endStatement();
+		}
+		
+		@Override
+		public void phase3() {
+			Constant newMaxScore = queryMaxScore();
+			isSame = maxScore.equals(newMaxScore);
+			tx.commit();
+		}
+		
+		public boolean isSame() {
+			return isSame;
+		}
+		
+		private Constant queryMaxScore() {
+			Planner planner = VanillaDb.newPlanner();
+			Plan p = planner.createQueryPlan("SELECT MAX(score) FROM test WHERE age = 20", tx);
+			Scan s = p.open();
+			s.beforeFirst();
+			s.next();
+			Constant value = s.getVal("maxofscore");
+			s.close();
+			return value;
+		}
+	}
+	
+	private static class Tx2Client extends TxClient {
+		public Tx2Client(Transaction tx, CyclicBarrier barrier) {
+			super(tx, barrier);
+		}
+		
+		@Override
+		public void phase2() {
+			try {
+				Planner planner = VanillaDb.newPlanner();
+				planner.executeUpdate("UPDATE test SET age = 20 WHERE age = 23", tx);
+			} catch (LockAbortException e) {
+				// It is normal to be aborted here.
+			}
+			tx.commit();
+		}
+	}
+}

--- a/src/test/java/org/vanilladb/core/integration/PhantomTest.java
+++ b/src/test/java/org/vanilladb/core/integration/PhantomTest.java
@@ -1,4 +1,4 @@
-package org.vanilladb.core.integrated;
+package org.vanilladb.core.integration;
 
 import java.sql.Connection;
 import java.util.concurrent.BrokenBarrierException;


### PR DESCRIPTION
As the title, the original system may happen phantom reads due to updates. I added an integration test case for the particular case. I also fixed the problem using locks on the leaves of B-trees. Note that this prevention only works when the search key is indexed using B-trees.