### PR TITLE
Apply the optimizations and bugfixes found in the experiments

### DIFF
--- a/src/main/java/org/vanilladb/core/query/algebra/ExplainScan.java
+++ b/src/main/java/org/vanilladb/core/query/algebra/ExplainScan.java
@@ -28,7 +28,7 @@ public class ExplainScan implements Scan {
 	private String result;
 	private int numRecs;
 	private Schema schema;
-	private boolean isBeforeFirst;
+	private boolean isBeforeFirsted;
 
 	/**
 	 * Creates a explain scan having the specified underlying query.
@@ -48,7 +48,7 @@ public class ExplainScan implements Scan {
 			numRecs++;
 		s.close();
 		this.result = result + "\nActual #recs: " + numRecs;
-		isBeforeFirst = true;
+		isBeforeFirsted = true;
 	}
 
 	@Override
@@ -61,13 +61,13 @@ public class ExplainScan implements Scan {
 
 	@Override
 	public void beforeFirst() {
-		isBeforeFirst = true;
+		isBeforeFirsted = true;
 	}
 
 	@Override
 	public boolean next() {
-		if (isBeforeFirst) {
-			isBeforeFirst = false;
+		if (isBeforeFirsted) {
+			isBeforeFirsted = false;
 			return true;
 		} else
 			return false;

--- a/src/main/java/org/vanilladb/core/query/algebra/ExplainScan.java
+++ b/src/main/java/org/vanilladb/core/query/algebra/ExplainScan.java
@@ -48,6 +48,7 @@ public class ExplainScan implements Scan {
 			numRecs++;
 		s.close();
 		this.result = result + "\nActual #recs: " + numRecs;
+		isBeforeFirst = true;
 	}
 
 	@Override

--- a/src/main/java/org/vanilladb/core/query/algebra/ProductScan.java
+++ b/src/main/java/org/vanilladb/core/query/algebra/ProductScan.java
@@ -36,8 +36,6 @@ public class ProductScan implements Scan {
 	public ProductScan(Scan s1, Scan s2) {
 		this.s1 = s1;
 		this.s2 = s2;
-		s1.beforeFirst();
-		isLhsEmpty = !s1.next();
 	}
 
 	/**

--- a/src/main/java/org/vanilladb/core/query/algebra/index/IndexJoinScan.java
+++ b/src/main/java/org/vanilladb/core/query/algebra/index/IndexJoinScan.java
@@ -55,7 +55,6 @@ public class IndexJoinScan implements Scan {
 		this.idx = idx;
 		this.joinFields = joinFields;
 		this.ts = ts;
-		beforeFirst();
 	}
 
 	/**

--- a/src/main/java/org/vanilladb/core/query/algebra/index/IndexSelectScan.java
+++ b/src/main/java/org/vanilladb/core/query/algebra/index/IndexSelectScan.java
@@ -45,7 +45,6 @@ public class IndexSelectScan implements UpdateScan {
 		this.idx = idx;
 		this.searchRange = searchRange;
 		this.ts = ts;
-		beforeFirst();
 	}
 
 	/**

--- a/src/main/java/org/vanilladb/core/query/algebra/materialize/GroupByScan.java
+++ b/src/main/java/org/vanilladb/core/query/algebra/materialize/GroupByScan.java
@@ -47,7 +47,6 @@ public class GroupByScan implements Scan {
 		this.ss = s;
 		this.groupFlds = groupFlds;
 		this.aggFns = aggFns;
-		beforeFirst();
 	}
 
 	/**

--- a/src/main/java/org/vanilladb/core/query/algebra/materialize/MergeJoinScan.java
+++ b/src/main/java/org/vanilladb/core/query/algebra/materialize/MergeJoinScan.java
@@ -45,7 +45,6 @@ public class MergeJoinScan implements Scan {
 		this.ss2 = ss2;
 		this.fldName1 = fldName1;
 		this.fldName2 = fldName2;
-		beforeFirst();
 	}
 
 	/**

--- a/src/main/java/org/vanilladb/core/query/algebra/materialize/SortScan.java
+++ b/src/main/java/org/vanilladb/core/query/algebra/materialize/SortScan.java
@@ -46,13 +46,8 @@ public class SortScan implements Scan {
 	public SortScan(List<TempTable> runs, RecordComparator comp) {
 		this.comp = comp;
 		s1 = (UpdateScan) runs.get(0).open();
-		s1.beforeFirst();
-		hasMore1 = s1.next();
-		if (runs.size() > 1) {
+		if (runs.size() > 1)
 			s2 = (UpdateScan) runs.get(1).open();
-			s2.beforeFirst();
-			hasMore2 = s2.next();
-		}
 	}
 
 	/**

--- a/src/main/java/org/vanilladb/core/query/algebra/multibuffer/ChunkScan.java
+++ b/src/main/java/org/vanilladb/core/query/algebra/multibuffer/ChunkScan.java
@@ -59,7 +59,6 @@ public class ChunkScan implements Scan {
 			BlockId blk = new BlockId(fileName, i);
 			pages.add(new RecordPage(blk, ti, tx, true));
 		}
-		beforeFirst();
 	}
 
 	/**

--- a/src/main/java/org/vanilladb/core/query/algebra/multibuffer/HashJoinScan.java
+++ b/src/main/java/org/vanilladb/core/query/algebra/multibuffer/HashJoinScan.java
@@ -46,7 +46,6 @@ public class HashJoinScan implements Scan {
 		Expression exp2 = new FieldNameExpression(fldname2);
 		Term t = new Term(exp1, OP_EQ, exp2);
 		pred = new Predicate(t);
-		beforeFirst();
 	}
 
 	@Override

--- a/src/main/java/org/vanilladb/core/remote/storedprocedure/SpResultSet.java
+++ b/src/main/java/org/vanilladb/core/remote/storedprocedure/SpResultSet.java
@@ -22,11 +22,13 @@ import org.vanilladb.core.sql.Schema;
 
 public class SpResultSet implements Serializable {
 
-	private static final long serialVersionUID = -8409489171990111489L;
-	private Record[] records;
-	private Schema schema;
+	private static final long serialVersionUID = 1L;
 
-	public SpResultSet(Schema schema, Record... records) {
+	private boolean isCommitted;
+	private Schema schema;
+	private Record[] records;
+
+	public SpResultSet(boolean isCommitted, Schema schema, Record... records) {
 		this.records = records;
 		this.schema = schema;
 	}
@@ -37,5 +39,9 @@ public class SpResultSet implements Serializable {
 
 	public Schema getSchema() {
 		return schema;
+	}
+	
+	public boolean isCommitted() {
+		return isCommitted;
 	}
 }

--- a/src/main/java/org/vanilladb/core/server/VanillaDb.java
+++ b/src/main/java/org/vanilladb/core/server/VanillaDb.java
@@ -141,9 +141,11 @@ public class VanillaDb {
 				logger.info("creating new database...");
 		} else {
 			if (logger.isLoggable(Level.INFO))
-				logger.info("recovering existing database");
+				logger.info("recovering existing database...");
 			// add a checkpoint record to limit rollback
 			RecoveryMgr.initializeSystem(initTx);
+			if (logger.isLoggable(Level.INFO))
+				logger.info("the database has been recovered to a consistent state.");
 		}
 
 		// initialize the statistics manager to build the histogram

--- a/src/main/java/org/vanilladb/core/sql/storedprocedure/StoredProcedureParamHelper.java
+++ b/src/main/java/org/vanilladb/core/sql/storedprocedure/StoredProcedureParamHelper.java
@@ -17,8 +17,6 @@ package org.vanilladb.core.sql.storedprocedure;
 
 import org.vanilladb.core.remote.storedprocedure.SpResultSet;
 import org.vanilladb.core.sql.Schema;
-import org.vanilladb.core.sql.Type;
-import org.vanilladb.core.sql.VarcharConstant;
 
 public abstract class StoredProcedureParamHelper {
 
@@ -48,12 +46,8 @@ public abstract class StoredProcedureParamHelper {
 			public SpResultSet createResultSet() {
 				// Return the result
 				Schema sch = new Schema();
-				Type t = Type.VARCHAR(10);
-				sch.addField("status", t);
 				SpResultRecord rec = new SpResultRecord();
-				String status = isCommitted ? "committed" : "abort";
-				rec.setVal("status", new VarcharConstant(status, t));
-				return new SpResultSet(sch, rec);
+				return new SpResultSet(isCommitted, sch, rec);
 			}
 		};
 	}
@@ -73,5 +67,4 @@ public abstract class StoredProcedureParamHelper {
 	public boolean isCommitted() {
 		return isCommitted;
 	}
-
 }

--- a/src/main/java/org/vanilladb/core/storage/buffer/BufferPoolMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/buffer/BufferPoolMgr.java
@@ -48,7 +48,7 @@ class BufferPoolMgr {
 	 */
 	BufferPoolMgr(int numBuffs) {
 		bufferPool = new Buffer[numBuffs];
-		blockMap = new ConcurrentHashMap<BlockId, Buffer>();
+		blockMap = new ConcurrentHashMap<BlockId, Buffer>(numBuffs);
 		numAvailable = new AtomicInteger(numBuffs);
 		lastReplacedBuff = 0;
 		for (int i = 0; i < numBuffs; i++)
@@ -75,25 +75,6 @@ class BufferPoolMgr {
 			try {
 				buff.getExternalLock().lock();
 				buff.flush();
-			} finally {
-				buff.getExternalLock().unlock();
-			}
-		}
-	}
-
-	/**
-	 * Flushes the dirty buffers modified by the specified transaction.
-	 * 
-	 * @param txNum
-	 *            the transaction's id number
-	 */
-	void flushAll(long txNum) {
-		for (Buffer buff : bufferPool) {
-			try {
-				buff.getExternalLock().lock();
-				if (buff.isModifiedBy(txNum)) {
-					buff.flush();
-				}
 			} finally {
 				buff.getExternalLock().unlock();
 			}

--- a/src/main/java/org/vanilladb/core/storage/index/btree/BTreeIndex.java
+++ b/src/main/java/org/vanilladb/core/storage/index/btree/BTreeIndex.java
@@ -41,8 +41,8 @@ public class BTreeIndex extends Index {
 	private String leafFileName, dirFileName;
 	private BTreeLeaf leaf = null;
 	private BlockId rootBlk;
-
 	private List<BlockId> dirsMayBeUpdated;
+	private boolean isBeforeFirsted;
 
 	public static long searchCost(SearchKeyType keyType, long totRecs, long matchRecs) {
 		int dirRpb = Buffer.BUFFER_SIZE / BTreePage.slotSize(BTreeDir.schema(keyType));
@@ -121,6 +121,7 @@ public class BTreeIndex extends Index {
 			return;
 
 		search(searchRange, SearchPurpose.READ);
+		isBeforeFirsted = true;
 	}
 
 	/**
@@ -132,6 +133,10 @@ public class BTreeIndex extends Index {
 	 */
 	@Override
 	public boolean next() {
+		if (!isBeforeFirsted)
+			throw new IllegalStateException("You must call beforeFirst() before iterating index '"
+					+ ii.indexName() + "'");
+		
 		return leaf == null ? false : leaf.next();
 	}
 

--- a/src/main/java/org/vanilladb/core/storage/index/hash/HashIndex.java
+++ b/src/main/java/org/vanilladb/core/storage/index/hash/HashIndex.java
@@ -84,6 +84,7 @@ public class HashIndex extends Index {
 	
 	private SearchKey searchKey;
 	private RecordFile rf;
+	private boolean isBeforeFirsted;
 
 	/**
 	 * Opens a hash index for the specified index.
@@ -139,6 +140,8 @@ public class HashIndex extends Index {
 		if (rf.fileSize() == 0)
 			RecordFile.formatFileHeader(ti.fileName(), tx);
 		rf.beforeFirst();
+		
+		isBeforeFirsted = true;
 	}
 
 	/**
@@ -148,6 +151,10 @@ public class HashIndex extends Index {
 	 */
 	@Override
 	public boolean next() {
+		if (!isBeforeFirsted)
+			throw new IllegalStateException("You must call beforeFirst() before iterating index '"
+					+ ii.indexName() + "'");
+		
 		while (rf.next())
 			if (getKey().equals(searchKey))
 				return true;

--- a/src/main/java/org/vanilladb/core/storage/metadata/index/IndexMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/metadata/index/IndexMgr.java
@@ -101,8 +101,12 @@ public class IndexMgr {
 			tblMgr.createTable(KCAT, sch, tx);
 		}
 		
-		idxTi = tblMgr.getTableInfo(ICAT, tx);
-		keyTi = tblMgr.getTableInfo(KCAT, tx);
+		idxTi = tblMgr.getTableInfo(ICAT, tx); 
+		if (idxTi == null) 
+			throw new RuntimeException("cannot find the catalog file for indices"); 
+		keyTi = tblMgr.getTableInfo(KCAT, tx); 
+		if (keyTi == null) 
+			throw new RuntimeException("cannot find the catalog file for the keys of indices"); 
 		
 		/*
 		 * Optimization: store the ii. WARNING: if allowing run-time index

--- a/src/main/java/org/vanilladb/core/storage/metadata/statistics/StatMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/metadata/statistics/StatMgr.java
@@ -20,6 +20,8 @@ import static org.vanilladb.core.storage.metadata.TableMgr.TCAT_TBLNAME;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.vanilladb.core.server.VanillaDb;
 import org.vanilladb.core.sql.Schema;
@@ -35,6 +37,8 @@ import org.vanilladb.core.util.CoreProperties;
  * startup, keeps the information in memory, and periodically refreshes it.
  */
 public class StatMgr {
+	private static Logger logger = Logger.getLogger(StatMgr.class.getName());
+	
 	// if REFRESH_THRESHOLD == 0, the refresh process will be turned off
 	private static final int REFRESH_THRESHOLD;
 	private static final int NUM_BUCKETS;
@@ -61,10 +65,16 @@ public class StatMgr {
 	 * @param tx
 	 *            the startup transaction
 	 */
-	public StatMgr(Transaction tx) {
+	public StatMgr(Transaction tx) {	
+		if (logger.isLoggable(Level.INFO)) 
+			logger.info("building statistics...");
+		
 		initStatistics(tx);
 		// Check refresh_threshold value to turn on/off the statistics
 		isRefreshStatOn = !(REFRESH_THRESHOLD == REFRESH_STAT_OFF);
+		
+		if (logger.isLoggable(Level.INFO)) 
+			logger.info("the statistics is up to date.");
 	}
 
 	/**

--- a/src/main/java/org/vanilladb/core/storage/record/RecordFile.java
+++ b/src/main/java/org/vanilladb/core/storage/record/RecordFile.java
@@ -49,6 +49,7 @@ public class RecordFile implements Record {
 	private FileHeaderPage fhp;
 	private long currentBlkNum;
 	private boolean doLog;
+	private boolean isBeforeFirsted;
 
 	/**
 	 * Constructs an object to manage a file of records. If the file does not
@@ -116,6 +117,7 @@ public class RecordFile implements Record {
 	public void beforeFirst() {
 		close();
 		currentBlkNum = 0; // first data block is block 1
+		isBeforeFirsted = true;
 	}
 
 	/**
@@ -124,6 +126,10 @@ public class RecordFile implements Record {
 	 * @return false if there is no next record.
 	 */
 	public boolean next() {
+		if (!isBeforeFirsted)
+			throw new IllegalStateException("You must call beforeFirst() before iterating table '"
+					+ ti.tableName() + "'");
+		
 		if (currentBlkNum == 0 && !moveTo(1))
 			return false;
 		while (true) {

--- a/src/main/java/org/vanilladb/core/storage/tx/TransactionMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/tx/TransactionMgr.java
@@ -184,6 +184,12 @@ public class TransactionMgr implements TransactionLifecycleListener {
 			return nextTxNum;
 		}
 	}
+	 
+	public int getActiveTxCount() { 
+		synchronized (this) { 
+			return activeTxs.size(); 
+		} 
+	}
 
 	private Transaction createTransaction(int isolationLevel, boolean readOnly, long txNum) {
 		if (logger.isLoggable(Level.FINE))

--- a/src/main/java/org/vanilladb/core/storage/tx/concurrency/RepeatableReadConcurrencyMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/tx/concurrency/RepeatableReadConcurrencyMgr.java
@@ -114,6 +114,8 @@ public class RepeatableReadConcurrencyMgr extends ConcurrencyMgr {
 	
 	@Override
 	public void modifyLeafBlock(BlockId blk) {
+		// Hold the index locks until the end of the transaction
+		// in order to prevent Serializable transactions from phantoms
 		lockTbl.xLock(blk, txNum);
 	}
 	

--- a/src/main/java/org/vanilladb/core/storage/tx/concurrency/SerializableConcurrencyMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/tx/concurrency/SerializableConcurrencyMgr.java
@@ -94,11 +94,15 @@ public class SerializableConcurrencyMgr extends ConcurrencyMgr {
 	
 	@Override
 	public void modifyLeafBlock(BlockId blk) {
+		// Hold the index locks until the end of the transaction
+		// in order to prevent phantoms
 		lockTbl.xLock(blk, txNum);
 	}
 	
 	@Override
 	public void readLeafBlock(BlockId blk) {
+		// Hold the index locks until the end of the transaction
+		// in order to prevent phantoms
 		lockTbl.sLock(blk, txNum);
 	}
 }

--- a/src/test/java/org/vanilladb/core/remote/storedprocedure/SpResultSetTest.java
+++ b/src/test/java/org/vanilladb/core/remote/storedprocedure/SpResultSetTest.java
@@ -34,7 +34,6 @@ import org.vanilladb.core.sql.IntegerConstant;
 import org.vanilladb.core.sql.Record;
 import org.vanilladb.core.sql.Schema;
 import org.vanilladb.core.sql.Type;
-import org.vanilladb.core.sql.VarcharConstant;
 import org.vanilladb.core.sql.storedprocedure.SpResultRecord;
 
 public class SpResultSetTest {
@@ -56,7 +55,6 @@ public class SpResultSetTest {
 	public void testInsertData() {
 		try {
 			Schema schema = new Schema();
-			schema.addField("status", Type.VARCHAR(10));
 			schema.addField("totalAoumnt", Type.DOUBLE);
 			schema.addField("cid", Type.INTEGER);
 			schema.addField("date", Type.BIGINT);
@@ -64,13 +62,12 @@ public class SpResultSetTest {
 			Record[] recs = new Record[10];
 			for (int i = 0; i < recs.length; i++) {
 				SpResultRecord r = new SpResultRecord();
-				r.setVal("status", new VarcharConstant("commit"));
 				r.setVal("totaFlAoumnt", new DoubleConstant(5962348.1));
 				r.setVal("cid", new IntegerConstant(i));
 				r.setVal("date", new BigIntConstant(i * 698));
 				recs[i] = r;
 			}
-			SpResultSet sp = new SpResultSet(schema, recs);
+			SpResultSet sp = new SpResultSet(true, schema, recs);
 
 			FileOutputStream fos;
 

--- a/src/test/java/org/vanilladb/core/storage/tx/concurrency/ConcurrencyTest.java
+++ b/src/test/java/org/vanilladb/core/storage/tx/concurrency/ConcurrencyTest.java
@@ -51,6 +51,12 @@ public class ConcurrencyTest {
 
 	@BeforeClass
 	public static void init() {
+		// Make the waiting time shorter
+		System.setProperty(
+			"org.vanilladb.core.storage.tx.concurrency.LockTable.MAX_TIME",
+			"1000"
+		);
+		
 		ServerInit.init(ConcurrencyTest.class);
 		ServerInit.loadTestbed();
 

--- a/src/test/java/org/vanilladb/core/storage/tx/recovery/RecoveryBasicTest.java
+++ b/src/test/java/org/vanilladb/core/storage/tx/recovery/RecoveryBasicTest.java
@@ -117,7 +117,7 @@ public class RecoveryBasicTest {
 		buff.setVal(504, new IntegerConstant(0), txNum, null);
 		buff.setVal(520, new VarcharConstant("aaaa"), txNum, null);
 		buff.setVal(540, new VarcharConstant("AAAA"), txNum, null);
-		tx.bufferMgr().flushAll(txNum);
+		tx.bufferMgr().flushAllMyBuffers();
 		tx.bufferMgr().unpin(buff);
 		tx.commit();
 	}
@@ -139,7 +139,7 @@ public class RecoveryBasicTest {
 		buff.setVal(20, new VarcharConstant("xyz"), txNum, lsn);
 
 		bm.unpin(buff);
-		bm.flushAll(txNum);
+		bm.flushAllMyBuffers();
 
 		// verify that the changes got made
 		buff = bm.pin(blk);


### PR DESCRIPTION
This merge applies the following modifications and optimizations:
- Remove unnecessary beforeFirst calls in constructors of Scans
- Make the waiting time in the test cases shorter
- Add more messages for starting up the system
- Reduce memory footprint in Buffers
- Add a new API to TransactionMgr 
- Add an error check to IndexMgr
- Correct the implementation of ConcurrencyMgr