### PR TITLE
A few bugfixes for B-Trees and Stored Procedures

### DIFF
--- a/src/main/java/org/vanilladb/core/remote/storedprocedure/SpResultSet.java
+++ b/src/main/java/org/vanilladb/core/remote/storedprocedure/SpResultSet.java
@@ -29,6 +29,7 @@ public class SpResultSet implements Serializable {
 	private Record[] records;
 
 	public SpResultSet(boolean isCommitted, Schema schema, Record... records) {
+		this.isCommitted = isCommitted;
 		this.records = records;
 		this.schema = schema;
 	}

--- a/src/main/java/org/vanilladb/core/sql/Type.java
+++ b/src/main/java/org/vanilladb/core/sql/Type.java
@@ -29,28 +29,6 @@ public abstract class Type {
 	};
 
 	/**
-	 * Constructs a new instance corresponding to the specified SQL type.
-	 * 
-	 * @param sqlType
-	 *            the corresponding SQL type
-	 * @return a new instance corresponding to the specified SQL type
-	 */
-	public static Type newInstance(int sqlType) {
-		switch (sqlType) {
-		case (java.sql.Types.INTEGER):
-			return INTEGER;
-		case (java.sql.Types.BIGINT):
-			return BIGINT;
-		case (java.sql.Types.DOUBLE):
-			return DOUBLE;
-		case (java.sql.Types.VARCHAR):
-			return VARCHAR;
-		}
-		throw new UnsupportedOperationException("Unspported SQL type: "
-				+ sqlType);
-	}
-
-	/**
 	 * Constructs a new instance corresponding to the specified SQL type and
 	 * argument.
 	 * 

--- a/src/main/java/org/vanilladb/core/sql/storedprocedure/ManuallyAbortException.java
+++ b/src/main/java/org/vanilladb/core/sql/storedprocedure/ManuallyAbortException.java
@@ -1,0 +1,15 @@
+package org.vanilladb.core.sql.storedprocedure;
+
+public class ManuallyAbortException extends RuntimeException {
+
+	private static final long serialVersionUID = 20200211001L;
+	
+	public ManuallyAbortException() {
+		super();
+	}
+	
+	public ManuallyAbortException(String message) {
+		super(message);
+	}
+
+}

--- a/src/main/java/org/vanilladb/core/sql/storedprocedure/SampleStoredProcedureFactory.java
+++ b/src/main/java/org/vanilladb/core/sql/storedprocedure/SampleStoredProcedureFactory.java
@@ -18,7 +18,7 @@ package org.vanilladb.core.sql.storedprocedure;
 public class SampleStoredProcedureFactory implements StoredProcedureFactory {
 
 	@Override
-	public StoredProcedure getStroredProcedure(int pid) {
+	public StoredProcedure<?> getStroredProcedure(int pid) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/src/main/java/org/vanilladb/core/sql/storedprocedure/SpResultRecord.java
+++ b/src/main/java/org/vanilladb/core/sql/storedprocedure/SpResultRecord.java
@@ -48,14 +48,17 @@ public class SpResultRecord implements Record, Serializable {
 
 	@Override
 	public String toString() {
-		StringBuilder sb = new StringBuilder("[");
-		Set<String> flds = new TreeSet<String>(fldValueMap.keySet());
-		for (String fld : flds)
-			sb.append(fld).append("=").append(fldValueMap.get(fld))
-					.append(", ");
-		int end = sb.length();
-		sb.replace(end - 2, end, "] ");
-		return sb.toString();
+		if (fldValueMap.size() > 0) {
+			StringBuilder sb = new StringBuilder("[");
+			Set<String> flds = new TreeSet<String>(fldValueMap.keySet());
+			for (String fld : flds)
+				sb.append(fld).append("=").append(fldValueMap.get(fld))
+						.append(", ");
+			int end = sb.length();
+			sb.replace(end - 2, end, "] ");
+			return sb.toString();
+		} else
+			return "[]";
 	}
 
 	@Override

--- a/src/main/java/org/vanilladb/core/sql/storedprocedure/SpResultRecord.java
+++ b/src/main/java/org/vanilladb/core/sql/storedprocedure/SpResultRecord.java
@@ -89,6 +89,7 @@ public class SpResultRecord implements Record, Serializable {
 			byte[] bytes = val.asBytes();
 			out.writeObject(fld);
 			out.writeInt(val.getType().getSqlType());
+			out.writeInt(val.getType().getArgument());
 			out.writeInt(bytes.length);
 			out.write(bytes);
 		}
@@ -104,10 +105,11 @@ public class SpResultRecord implements Record, Serializable {
 		for (int i = 0; i < numFlds; i++) {
 			String fld = (String) in.readObject();
 			int sqlType = in.readInt();
+			int sqlArg = in.readInt();
 			byte[] bytes = new byte[in.readInt()];
 			in.read(bytes);
-			Constant val = Constant.newInstance(Type.newInstance(sqlType),
-					bytes);
+			Constant val = Constant.newInstance(
+					Type.newInstance(sqlType, sqlArg), bytes);
 			fldValueMap.put(fld, val);
 		}
 

--- a/src/main/java/org/vanilladb/core/sql/storedprocedure/StoredProcedure.java
+++ b/src/main/java/org/vanilladb/core/sql/storedprocedure/StoredProcedure.java
@@ -19,6 +19,7 @@ import java.sql.Connection;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.vanilladb.core.query.planner.BadSemanticException;
 import org.vanilladb.core.remote.storedprocedure.SpResultSet;
 import org.vanilladb.core.server.VanillaDb;
 import org.vanilladb.core.storage.tx.Transaction;
@@ -65,6 +66,14 @@ public abstract class StoredProcedure<H extends StoredProcedureParamHelper> {
 			if (logger.isLoggable(Level.WARNING))
 				logger.warning(lockAbortEx.getMessage());
 			tx.rollback();
+		} catch (ManuallyAbortException me) {
+			if (logger.isLoggable(Level.WARNING))
+				logger.warning("Manually aborted by the procedure: " + me.getMessage());
+			tx.rollback();
+		} catch (BadSemanticException be) {
+			if (logger.isLoggable(Level.SEVERE))
+				logger.warning("Semantic error: " + be.getMessage());
+			tx.rollback();
 		} catch (Exception e) {
 			e.printStackTrace();
 			tx.rollback();
@@ -85,5 +94,13 @@ public abstract class StoredProcedure<H extends StoredProcedureParamHelper> {
 	
 	protected Transaction getTransaction() {
 		return tx;
+	}
+	
+	protected void abort() {
+		throw new ManuallyAbortException();
+	}
+	
+	protected void abort(String message) {
+		throw new ManuallyAbortException(message);
 	}
 }

--- a/src/main/java/org/vanilladb/core/sql/storedprocedure/StoredProcedureFactory.java
+++ b/src/main/java/org/vanilladb/core/sql/storedprocedure/StoredProcedureFactory.java
@@ -17,6 +17,6 @@ package org.vanilladb.core.sql.storedprocedure;
 
 public interface StoredProcedureFactory {
 	
-	StoredProcedure getStroredProcedure(int pid);
+	StoredProcedure<?> getStroredProcedure(int pid);
 	
 }

--- a/src/main/java/org/vanilladb/core/sql/storedprocedure/StoredProcedureParamHelper.java
+++ b/src/main/java/org/vanilladb/core/sql/storedprocedure/StoredProcedureParamHelper.java
@@ -20,7 +20,7 @@ import org.vanilladb.core.sql.Schema;
 
 public abstract class StoredProcedureParamHelper {
 
-	protected boolean isCommitted = true;
+	private boolean isCommitted = true;
 	private boolean isReadOnly = false;
 
 	/**
@@ -47,7 +47,7 @@ public abstract class StoredProcedureParamHelper {
 				// Return the result
 				Schema sch = new Schema();
 				SpResultRecord rec = new SpResultRecord();
-				return new SpResultSet(isCommitted, sch, rec);
+				return new SpResultSet(isCommitted(), sch, rec);
 			}
 		};
 	}
@@ -55,13 +55,13 @@ public abstract class StoredProcedureParamHelper {
 	protected void setReadOnly(boolean isReadOnly) {
 		this.isReadOnly = isReadOnly;
 	}
+
+	void setCommitted(boolean b) {
+		isCommitted = b;
+	}
 	
 	public boolean isReadOnly() {
 		return isReadOnly;
-	}
-
-	public void setCommitted(boolean b) {
-		isCommitted = b;
 	}
 
 	public boolean isCommitted() {

--- a/src/main/java/org/vanilladb/core/sql/storedprocedure/StoredProcedureParamHelper.java
+++ b/src/main/java/org/vanilladb/core/sql/storedprocedure/StoredProcedureParamHelper.java
@@ -15,12 +15,29 @@
  *******************************************************************************/
 package org.vanilladb.core.sql.storedprocedure;
 
-import org.vanilladb.core.remote.storedprocedure.SpResultSet;
 import org.vanilladb.core.sql.Schema;
 
 public abstract class StoredProcedureParamHelper {
 
-	private boolean isCommitted = true;
+	public static StoredProcedureParamHelper newDefaultParamHelper() {
+		return new StoredProcedureParamHelper() {
+			@Override
+			public void prepareParameters(Object... pars) {
+				// do nothing
+			}
+			
+			@Override
+			public Schema getResultSetSchema() {
+				return new Schema();
+			}
+
+			@Override
+			public SpResultRecord newResultSetRecord() {
+				return new SpResultRecord();
+			}
+		};
+	}
+
 	private boolean isReadOnly = false;
 
 	/**
@@ -31,40 +48,16 @@ public abstract class StoredProcedureParamHelper {
 	 *            procedure.
 	 */
 	public abstract void prepareParameters(Object... pars);
-
-	public abstract SpResultSet createResultSet();
-
-	public static StoredProcedureParamHelper DefaultParamHelper() {
-		return new StoredProcedureParamHelper() {
-
-			@Override
-			public void prepareParameters(Object... pars) {
-				// do nothing
-			}
-
-			@Override
-			public SpResultSet createResultSet() {
-				// Return the result
-				Schema sch = new Schema();
-				SpResultRecord rec = new SpResultRecord();
-				return new SpResultSet(isCommitted(), sch, rec);
-			}
-		};
-	}
+	
+	public abstract Schema getResultSetSchema();
+	
+	public abstract SpResultRecord newResultSetRecord();
 	
 	protected void setReadOnly(boolean isReadOnly) {
 		this.isReadOnly = isReadOnly;
 	}
-
-	void setCommitted(boolean b) {
-		isCommitted = b;
-	}
 	
 	public boolean isReadOnly() {
 		return isReadOnly;
-	}
-
-	public boolean isCommitted() {
-		return isCommitted;
 	}
 }

--- a/src/main/java/org/vanilladb/core/storage/buffer/Buffer.java
+++ b/src/main/java/org/vanilladb/core/storage/buffer/Buffer.java
@@ -85,6 +85,9 @@ public class Buffer {
 	public Constant getVal(int offset, Type type) {
 		internalLock.readLock().lock();
 		try {
+			if (offset < 0 || offset >= BUFFER_SIZE)
+				throw new IndexOutOfBoundsException("" + offset);
+				
 			return contents.getVal(DATA_START_OFFSET + offset, type);
 		} finally {
 			internalLock.readLock().unlock();
@@ -94,6 +97,9 @@ public class Buffer {
 	void setVal(int offset, Constant val) {
 		internalLock.writeLock().lock();
 		try {
+			if (offset < 0 || offset >= BUFFER_SIZE)
+				throw new IndexOutOfBoundsException("" + offset);
+			
 			contents.setVal(DATA_START_OFFSET + offset, val);
 		} finally {
 			internalLock.writeLock().unlock();
@@ -119,6 +125,9 @@ public class Buffer {
 	public void setVal(int offset, Constant val, long txNum, LogSeqNum lsn) {
 		internalLock.writeLock().lock();
 		try {
+			if (offset < 0 || offset >= BUFFER_SIZE)
+				throw new IndexOutOfBoundsException("" + offset);
+			
 			isModified = true;
 			if (lsn != null && lsn.compareTo(lastLsn) > 0)
 				lastLsn = lsn;

--- a/src/main/java/org/vanilladb/core/storage/index/btree/BTreeDir.java
+++ b/src/main/java/org/vanilladb/core/storage/index/btree/BTreeDir.java
@@ -324,9 +324,6 @@ public class BTreeDir {
 
 	private long findChildBlockNumber(SearchKey searchKey) {
 		int slot = findMatchingSlot(searchKey);
-		System.out.println("Find slot " + slot);
-//		if (getKey(currentPage, slot + 1, keyType.length()).equals(searchKey))
-//			slot++;
 		return getChildBlockNumber(currentPage, slot);
 	}
 

--- a/src/main/java/org/vanilladb/core/storage/index/btree/BTreeDir.java
+++ b/src/main/java/org/vanilladb/core/storage/index/btree/BTreeDir.java
@@ -202,10 +202,16 @@ public class BTreeDir {
 	}
 
 	public DirEntry insert(DirEntry e) {
-		int newslot = 1 + findSlotBefore(e.key());
-		insert(newslot, e.key(), e.blockNumber());
+		// Find a slot for the entry
+		int newSlot = 0;
+		if (currentPage.getNumRecords() > 0)
+			newSlot = findMatchingSlot(e.key()) + 1;
+		
+		// Insert the entry to the slot (the data in the slot will be moved to the next slot) 
+		insert(newSlot, e.key(), e.blockNumber());
 		if (!currentPage.isFull())
 			return null;
+		
 		// split full page
 		int splitPos = currentPage.getNumRecords() / 2;
 		SearchKey splitVal = getKey(currentPage, splitPos, keyType.length());
@@ -317,26 +323,30 @@ public class BTreeDir {
 	}
 
 	private long findChildBlockNumber(SearchKey searchKey) {
-		int slot = findSlotBefore(searchKey);
-		if (getKey(currentPage, slot + 1, keyType.length()).equals(searchKey))
-			slot++;
+		int slot = findMatchingSlot(searchKey);
+		System.out.println("Find slot " + slot);
+//		if (getKey(currentPage, slot + 1, keyType.length()).equals(searchKey))
+//			slot++;
 		return getChildBlockNumber(currentPage, slot);
 	}
 
 	/**
-	 * Calculates the slot right before the one having the specified search key.
+	 * Finds the slot that contains a key that equals to or is smaller than the
+	 * specified search key while the key in the next slot is larger than the 
+	 * search key or there is no more slot behind.
 	 * 
 	 * @param searchKey
-	 *            the search key
-	 * @return the position before where the search key goes
+	 *            the key to search the slot
+	 * @return the id of the matching slot
 	 */
-	private int findSlotBefore(SearchKey searchKey) {
+	private int findMatchingSlot(SearchKey searchKey) {
+		// Sequential search
 		/*
 		 * int slot = 0; while (slot < contents.getNumRecords() &&
 		 * getKey(contents, slot).compareTo(searchKey) < 0) slot++; return slot
 		 * - 1;
 		 */
-		// Optimization: Use binary search rather than sequential search
+		// Optimization: Use binary search, instead of sequential search
 		int startSlot = 0, endSlot = currentPage.getNumRecords() - 1;
 		int middleSlot = (startSlot + endSlot) / 2;
 
@@ -351,15 +361,12 @@ public class BTreeDir {
 				middleSlot = (startSlot + endSlot) / 2;
 			}
 
-			if (getKey(currentPage, endSlot, keyType.length()).compareTo(searchKey) < 0)
+			if (getKey(currentPage, endSlot, keyType.length()).compareTo(searchKey) <= 0)
 				return endSlot;
-			else if (getKey(currentPage, startSlot, keyType.length())
-					.compareTo(searchKey) < 0)
-				return startSlot;
 			else
-				return startSlot - 1;
+				return startSlot;
 		} else
-			return -1;
+			return 0;
 	}
 
 	private void insert(int slot, SearchKey key, long blkNum) {

--- a/src/main/java/org/vanilladb/core/storage/index/btree/BTreeLeaf.java
+++ b/src/main/java/org/vanilladb/core/storage/index/btree/BTreeLeaf.java
@@ -300,7 +300,7 @@ public class BTreeLeaf {
 			setSiblingFlag(currentPage, newBlkNum);
 			return new DirEntry(splitKey, newBlkNum);
 		}
-		
+
 		if (!currentPage.isFull())
 			return null;
 		

--- a/src/main/java/org/vanilladb/core/storage/tx/Transaction.java
+++ b/src/main/java/org/vanilladb/core/storage/tx/Transaction.java
@@ -114,10 +114,8 @@ public class Transaction {
 	 * all locks, and unpins any pinned blocks.
 	 */
 	public void rollback() {
-		for (TransactionLifecycleListener l : lifecycleListeners) {
-
+		for (TransactionLifecycleListener l : lifecycleListeners)
 			l.onTxRollback(this);
-		}
 
 		if (logger.isLoggable(Level.FINE))
 			logger.fine("transaction " + txNum + " rolled back");

--- a/src/main/java/org/vanilladb/core/storage/tx/recovery/IndexDeleteEndRecord.java
+++ b/src/main/java/org/vanilladb/core/storage/tx/recovery/IndexDeleteEndRecord.java
@@ -65,7 +65,8 @@ public class IndexDeleteEndRecord extends LogicalEndRecord implements LogRecord 
 		Constant[] vals = new Constant[keyLen];
 		for (int i = 0; i < keyLen; i++) {
 			int type = (Integer) rec.nextVal(INTEGER).asJavaVal();
-			vals[i] = rec.nextVal(Type.newInstance(type));
+			int argument = (Integer) rec.nextVal(INTEGER).asJavaVal();
+			vals[i] = rec.nextVal(Type.newInstance(type, argument));
 		}
 		searchKey = new SearchKey(vals);
 		
@@ -141,6 +142,7 @@ public class IndexDeleteEndRecord extends LogicalEndRecord implements LogRecord 
 		for (int i = 0; i < searchKey.length(); i++) {
 			Constant val = searchKey.get(i);
 			rec.add(new IntegerConstant(val.getType().getSqlType()));
+			rec.add(new IntegerConstant(val.getType().getArgument()));
 			rec.add(val);
 		}
 		

--- a/src/main/java/org/vanilladb/core/storage/tx/recovery/IndexInsertEndRecord.java
+++ b/src/main/java/org/vanilladb/core/storage/tx/recovery/IndexInsertEndRecord.java
@@ -65,7 +65,8 @@ public class IndexInsertEndRecord extends LogicalEndRecord implements LogRecord 
 		Constant[] vals = new Constant[keyLen];
 		for (int i = 0; i < keyLen; i++) {
 			int type = (Integer) rec.nextVal(INTEGER).asJavaVal();
-			vals[i] = rec.nextVal(Type.newInstance(type));
+			int argument = (Integer) rec.nextVal(INTEGER).asJavaVal();
+			vals[i] = rec.nextVal(Type.newInstance(type, argument));
 		}
 		searchKey = new SearchKey(vals);
 		
@@ -142,6 +143,7 @@ public class IndexInsertEndRecord extends LogicalEndRecord implements LogRecord 
 		for (int i = 0; i < searchKey.length(); i++) {
 			Constant val = searchKey.get(i);
 			rec.add(new IntegerConstant(val.getType().getSqlType()));
+			rec.add(new IntegerConstant(val.getType().getArgument()));
 			rec.add(val);
 		}
 		

--- a/src/main/java/org/vanilladb/core/storage/tx/recovery/SetValueRecord.java
+++ b/src/main/java/org/vanilladb/core/storage/tx/recovery/SetValueRecord.java
@@ -37,7 +37,7 @@ import org.vanilladb.core.storage.tx.Transaction;
 class SetValueRecord implements LogRecord {
 	private long txNum;
 	private int offset;
-	private int type;
+	private Type type;
 	private Constant val;
 	private Constant newVal;
 	private BlockId blk;
@@ -61,7 +61,7 @@ class SetValueRecord implements LogRecord {
 		this.txNum = txNum;
 		this.blk = blk;
 		this.offset = offset;
-		this.type = val.getType().getSqlType();
+		this.type = val.getType();
 		this.val = val;
 		this.newVal = newVal;
 		this.lsn = null;
@@ -79,9 +79,11 @@ class SetValueRecord implements LogRecord {
 		txNum = (Long) rec.nextVal(BIGINT).asJavaVal();
 		blk = new BlockId((String) rec.nextVal(VARCHAR).asJavaVal(), (Long) rec.nextVal(BIGINT).asJavaVal());
 		offset = (Integer) rec.nextVal(INTEGER).asJavaVal();
-		type = (Integer) rec.nextVal(INTEGER).asJavaVal();
-		val = rec.nextVal(Type.newInstance(type));
-		newVal = rec.nextVal(Type.newInstance(type));
+		int sqlType = (Integer) rec.nextVal(INTEGER).asJavaVal();
+		int sqlArg = (Integer) rec.nextVal(INTEGER).asJavaVal();
+		type = Type.newInstance(sqlType, sqlArg);
+		val = rec.nextVal(type);
+		newVal = rec.nextVal(type);
 		lsn = rec.getLSN();
 	}
 
@@ -163,7 +165,8 @@ class SetValueRecord implements LogRecord {
 		rec.add(new VarcharConstant(blk.fileName()));
 		rec.add(new BigIntConstant(blk.number()));
 		rec.add(new IntegerConstant(offset));
-		rec.add(new IntegerConstant(type));
+		rec.add(new IntegerConstant(type.getSqlType()));
+		rec.add(new IntegerConstant(type.getArgument()));
 		rec.add(val);
 		rec.add(newVal);
 		return rec;

--- a/src/test/java/org/vanilladb/core/StorageTestSuite.java
+++ b/src/test/java/org/vanilladb/core/StorageTestSuite.java
@@ -26,7 +26,6 @@ import org.vanilladb.core.storage.buffer.BufferTest;
 import org.vanilladb.core.storage.buffer.LastLSNTest;
 import org.vanilladb.core.storage.file.FileTest;
 import org.vanilladb.core.storage.file.PageConcurrencyTest;
-import org.vanilladb.core.storage.index.btree.BTreeIndexConcurrentTest;
 import org.vanilladb.core.storage.index.btree.BTreeIndexTest;
 import org.vanilladb.core.storage.index.btree.BTreeLeafTest;
 import org.vanilladb.core.storage.index.btree.BTreePageTest;
@@ -37,6 +36,7 @@ import org.vanilladb.core.storage.record.RecordTest;
 import org.vanilladb.core.storage.tx.TxTest;
 import org.vanilladb.core.storage.tx.concurrency.ConcurrencyTest;
 import org.vanilladb.core.storage.tx.concurrency.LockTableTest;
+import org.vanilladb.core.storage.tx.recovery.BTreeIndexRecoveryTest;
 import org.vanilladb.core.storage.tx.recovery.RecoveryBasicTest;
 
 @RunWith(IsolatedClassLoaderSuite.class)
@@ -60,7 +60,7 @@ import org.vanilladb.core.storage.tx.recovery.RecoveryBasicTest;
 	
 	// storage.index.btree
 	BTreeIndexTest.class, BTreeLeafTest.class,
-	BTreePageTest.class, BTreeIndexConcurrentTest.class,
+	BTreePageTest.class,
 	
 	// storage.index.hash
 	HashIndexTest.class,
@@ -72,7 +72,7 @@ import org.vanilladb.core.storage.tx.recovery.RecoveryBasicTest;
 	ConcurrencyTest.class, LockTableTest.class,
 	
 	// storage.tx.recovery
-	RecoveryBasicTest.class,
+	RecoveryBasicTest.class, BTreeIndexRecoveryTest.class,
 })
 @IsolationRoot(VanillaDb.class)
 public class StorageTestSuite {

--- a/src/test/java/org/vanilladb/core/StorageTestSuite.java
+++ b/src/test/java/org/vanilladb/core/StorageTestSuite.java
@@ -26,6 +26,7 @@ import org.vanilladb.core.storage.buffer.BufferTest;
 import org.vanilladb.core.storage.buffer.LastLSNTest;
 import org.vanilladb.core.storage.file.FileTest;
 import org.vanilladb.core.storage.file.PageConcurrencyTest;
+import org.vanilladb.core.storage.index.btree.BTreeIndexConcurrentTest;
 import org.vanilladb.core.storage.index.btree.BTreeIndexTest;
 import org.vanilladb.core.storage.index.btree.BTreeLeafTest;
 import org.vanilladb.core.storage.index.btree.BTreePageTest;
@@ -59,7 +60,7 @@ import org.vanilladb.core.storage.tx.recovery.RecoveryBasicTest;
 	
 	// storage.index.btree
 	BTreeIndexTest.class, BTreeLeafTest.class,
-	BTreePageTest.class,
+	BTreePageTest.class, BTreeIndexConcurrentTest.class,
 	
 	// storage.index.hash
 	HashIndexTest.class,

--- a/src/test/java/org/vanilladb/core/storage/index/btree/BTreeIndexConcurrentTest.java
+++ b/src/test/java/org/vanilladb/core/storage/index/btree/BTreeIndexConcurrentTest.java
@@ -1,0 +1,109 @@
+package org.vanilladb.core.storage.index.btree;
+
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.vanilladb.core.query.planner.Planner;
+import org.vanilladb.core.server.ServerInit;
+import org.vanilladb.core.server.VanillaDb;
+import org.vanilladb.core.sql.Constant;
+import org.vanilladb.core.sql.Type;
+import org.vanilladb.core.sql.VarcharConstant;
+import org.vanilladb.core.storage.file.BlockId;
+import org.vanilladb.core.storage.index.Index;
+import org.vanilladb.core.storage.index.SearchKey;
+import org.vanilladb.core.storage.metadata.index.IndexInfo;
+import org.vanilladb.core.storage.record.RecordId;
+import org.vanilladb.core.storage.tx.Transaction;
+import org.vanilladb.core.storage.tx.concurrency.LockAbortException;
+
+public class BTreeIndexConcurrentTest {
+	private static Logger logger = Logger.getLogger(BTreeIndexConcurrentTest.class.getName());
+	
+	private static AtomicInteger nextInsertId = new AtomicInteger(1);
+	private static final Type ID_TYPE = Type.VARCHAR(33);
+	
+	@BeforeClass
+	public static void init() {
+		ServerInit.init(BTreeIndexConcurrentTest.class);
+		createIndex();
+		
+		if (logger.isLoggable(Level.INFO))
+			logger.info("BEGIN B-TREE CONCURRENCY TEST");
+	}
+	
+	@AfterClass
+	public static void finish() {
+		if (logger.isLoggable(Level.INFO))
+			logger.info("FINISH B-TREE CONCURRENCY TEST");
+	}
+	
+	private static void createIndex() {
+		Transaction tx = VanillaDb.txMgr().newTransaction(
+				Connection.TRANSACTION_SERIALIZABLE, false);
+		Planner planner = VanillaDb.newPlanner();
+		
+		// Create a table
+		planner.executeUpdate("CREATE TABLE test (id VARCHAR(33), val INT)", tx);
+		
+		// Create a B-Tree index
+		planner.executeUpdate("CREATE INDEX test_idx ON test (id) USING BTREE", tx);
+		
+		tx.commit();
+		
+		if (logger.isLoggable(Level.INFO))
+			logger.info("TESTING DATA CREATED");
+	}
+	
+	@Test
+	public void testConcurrentInsert() {
+		List<Thread> threads = new ArrayList<Thread>(100);
+		
+		for (int i = 0; i < 100; i++) {
+			Thread thread = new Thread(new Insertor());
+			thread.start();
+			threads.add(thread);
+		}
+		
+		for (Thread t : threads) {
+			try {
+				t.join();
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+			}
+		}
+	}
+	
+	static class Insertor implements Runnable {
+
+		@Override
+		public void run() {
+			Transaction tx = VanillaDb.txMgr().newTransaction(
+					Connection.TRANSACTION_SERIALIZABLE, false);
+			
+			try {
+				IndexInfo ii = VanillaDb.catalogMgr().getIndexInfo("test", "id", tx).get(0);
+				Index idx = ii.open(tx);
+				
+				int insertId = nextInsertId.getAndIncrement();
+				String idStr = String.format("%033d", insertId);
+				Constant idCon = new VarcharConstant(idStr, ID_TYPE);
+				RecordId fakeRid = new RecordId(new BlockId("test", insertId), 1);
+				
+				idx.insert(new SearchKey(idCon), fakeRid, true);
+				
+				tx.commit();
+			} catch (LockAbortException l) {
+				tx.rollback();
+			}
+		}
+		
+	}
+}

--- a/src/test/java/org/vanilladb/core/storage/tx/recovery/BTreeIndexRecoveryTest.java
+++ b/src/test/java/org/vanilladb/core/storage/tx/recovery/BTreeIndexRecoveryTest.java
@@ -1,0 +1,78 @@
+package org.vanilladb.core.storage.tx.recovery;
+
+import java.sql.Connection;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.vanilladb.core.query.planner.Planner;
+import org.vanilladb.core.server.ServerInit;
+import org.vanilladb.core.server.VanillaDb;
+import org.vanilladb.core.sql.Constant;
+import org.vanilladb.core.sql.Type;
+import org.vanilladb.core.sql.VarcharConstant;
+import org.vanilladb.core.storage.file.BlockId;
+import org.vanilladb.core.storage.index.Index;
+import org.vanilladb.core.storage.index.SearchKey;
+import org.vanilladb.core.storage.metadata.index.IndexInfo;
+import org.vanilladb.core.storage.record.RecordId;
+import org.vanilladb.core.storage.tx.Transaction;
+
+public class BTreeIndexRecoveryTest {
+	private static Logger logger = Logger.getLogger(BTreeIndexRecoveryTest.class.getName());
+
+	private static final Type ID_TYPE = Type.VARCHAR(33);
+	
+	@BeforeClass
+	public static void init() {
+		ServerInit.init(BTreeIndexRecoveryTest.class);
+		createIndex();
+		
+		if (logger.isLoggable(Level.INFO))
+			logger.info("BEGIN B-TREE RECOVERY TEST");
+	}
+	
+	@AfterClass
+	public static void finish() {
+		if (logger.isLoggable(Level.INFO))
+			logger.info("FINISH B-TREE RECOVERY TEST");
+	}
+	
+	private static void createIndex() {
+		Transaction tx = VanillaDb.txMgr().newTransaction(
+				Connection.TRANSACTION_SERIALIZABLE, false);
+		Planner planner = VanillaDb.newPlanner();
+		
+		// Create a table
+		planner.executeUpdate("CREATE TABLE test (id VARCHAR(33), val INT)", tx);
+		
+		// Create a B-Tree index
+		planner.executeUpdate("CREATE INDEX test_idx ON test (id) USING BTREE", tx);
+		
+		tx.commit();
+		
+		if (logger.isLoggable(Level.INFO))
+			logger.info("TESTING DATA CREATED");
+	}
+	
+	@Test
+	public void testVarcharIdRollback() {
+		Transaction tx = VanillaDb.txMgr().newTransaction(
+				Connection.TRANSACTION_SERIALIZABLE, false);
+		
+		IndexInfo ii = VanillaDb.catalogMgr().getIndexInfo("test", "id", tx).get(0);
+		Index idx = ii.open(tx);
+		
+		int insertId = 1;
+		String idStr = String.format("%033d", insertId);
+		Constant idCon = new VarcharConstant(idStr, ID_TYPE);
+		RecordId fakeRid = new RecordId(new BlockId("test", insertId), 1);
+		
+		idx.insert(new SearchKey(idCon), fakeRid, true);
+		
+		tx.rollback();
+	}
+
+}


### PR DESCRIPTION
## Stored Procedures

- Ensure that `SpResultSet` saves commit status
- Add missing generic parameters for stored procedures
- Fix the `toString` of `SpResultRecord`
- Update the visibility of the methods of `StoredProcedureParamHelper`
- Refactor the design and APIs of stored procedures
- Add a method to manually abort in a stored procedure

## BTree

- Add `BTreeIndexRecoveryTest` for the recovery of B-Tree
- Add `BTreeIndexConcurrentTest` for the concurrency of B-Tree
- Implement `toString` for `BTreePage`
- Fix the bug of searching an entry in `BTreeDir`
- Fix the bug of inserting an entry in `BTreeDir`
- Add a size check in `BTreePage`
- Fix a bug that causes overflow while rolling back in BTree