### PR TITLE
Resolve #49: bad verification while using aggregation fields after an order by clause

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,11 +91,6 @@
 			<artifactId>jaydio</artifactId>
 			<version>0.1</version>
 		</dependency>
-		<dependency>
-		  <groupId>com.google.googlejavaformat</groupId>
-		  <artifactId>google-java-format</artifactId>
-		  <version>1.9</version>
-		</dependency>
 	</dependencies>
 
 	<!-- For deploying to the central repository -->

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,10 @@
 			<name>Yun-Sheng Chang</name>
 			<email>yschang@datalab.cs.nthu.edu.tw</email>
 		</developer>
+		<developer>
+			<name>Pin-Yu Wang</name>
+			<email>pywang@datalab.cs.nthu.edu.tw</email>
+		</developer>
 	</developers>
 
 	<scm>
@@ -86,6 +90,11 @@
 			<groupId>net.smacke</groupId>
 			<artifactId>jaydio</artifactId>
 			<version>0.1</version>
+		</dependency>
+		<dependency>
+		  <groupId>com.google.googlejavaformat</groupId>
+		  <artifactId>google-java-format</artifactId>
+		  <version>1.9</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/org/vanilladb/core/query/planner/Verifier.java
+++ b/src/main/java/org/vanilladb/core/query/planner/Verifier.java
@@ -100,7 +100,18 @@ public class Verifier {
 		// Examine the sorting field name
 		if (data.sortFields() != null)
 			for (String sortFld : data.sortFields()) {
-				if (!verifyField(schs, views, sortFld))
+				boolean isValid = verifyField(schs, views, sortFld);
+				
+				// aggregation field may appear after order by
+				// example: select count(fld1), fld2 from table group by fld2 order by count(fld1);
+				// we need the following checks to make count(fld1) valid
+				if (!isValid && data.aggregationFn() != null)
+					for (AggregationFn aggFn : data.aggregationFn())
+						if (sortFld.compareTo(aggFn.fieldName()) == 0) {
+							isValid = true;
+							break;
+						}
+				if (!isValid)
 					throw new BadSemanticException("field " + sortFld
 							+ " does not exist");
 			}
@@ -133,6 +144,7 @@ public class Verifier {
 		for (int i = 0; i < fields.size(); i++) {
 			String field = fields.get(i);
 			Constant val = vals.get(i);
+			
 			// check field existence
 			if (!sch.hasField(field))
 				throw new BadSemanticException("field " + field
@@ -260,17 +272,18 @@ public class Verifier {
 	private static boolean verifyField(List<Schema> schs,
 			List<QueryData> views, String fld) {
 		boolean isValid = false;
-		for (Schema s : schs)
+		for (Schema s : schs) {
 			if (s.hasField(fld)) {
-				isValid = true;
-				break;
+				return true;
 			}
-		if (!isValid)
-			for (QueryData queryData : views)
-				if (queryData.projectFields().contains(fld)) {
-					isValid = true;
-					break;
-				}
+		}
+
+		for (QueryData queryData : views) {
+			if (queryData.projectFields().contains(fld)) {
+				return true;
+			}
+		}
+		
 		return isValid;
 	}
 }

--- a/src/main/java/org/vanilladb/core/query/planner/Verifier.java
+++ b/src/main/java/org/vanilladb/core/query/planner/Verifier.java
@@ -271,7 +271,6 @@ public class Verifier {
 
 	private static boolean verifyField(List<Schema> schs,
 			List<QueryData> views, String fld) {
-		boolean isValid = false;
 		for (Schema s : schs) {
 			if (s.hasField(fld)) {
 				return true;
@@ -284,6 +283,6 @@ public class Verifier {
 			}
 		}
 		
-		return isValid;
+		return false;
 	}
 }

--- a/src/test/java/org/vanilladb/core/query/planner/VerifierTest.java
+++ b/src/test/java/org/vanilladb/core/query/planner/VerifierTest.java
@@ -33,6 +33,7 @@ import org.vanilladb.core.query.parse.DeleteData;
 import org.vanilladb.core.query.parse.InsertData;
 import org.vanilladb.core.query.parse.ModifyData;
 import org.vanilladb.core.query.parse.Parser;
+import org.vanilladb.core.query.parse.QueryData;
 import org.vanilladb.core.server.ServerInit;
 import org.vanilladb.core.server.VanillaDb;
 import org.vanilladb.core.storage.tx.Transaction;
@@ -67,6 +68,22 @@ public class VerifierTest {
 	@After
 	public void finishTx() {
 		tx = null;
+	}
+	
+	@Test
+	public void testQueryData() {
+		try {
+			String qry = "select count(grade), eid from enroll group by eid order by count(grade) asc";
+			Parser psr = new Parser(qry);
+			QueryData data = (QueryData) psr.queryCommand();
+			Verifier.verifyQueryData(data, tx);
+			tx.commit();
+			
+		} catch(BadSemanticException e) {
+			tx.rollback();
+			System.err.println(e);
+			fail("QueryVerifierTest: bad verification");
+		}
 	}
 
 	@Test


### PR DESCRIPTION
#49 

It is not valid that Vanillacore returns errors while using aggregation fields after `order by` clause

for example:
`select count(fld1), fld2 from table group by fld2 order by count(fld1);`

In the verifier.java, it will consider the aggregation field `count(fld1)` after `order by` as invalid field.

## What I Did

1. I fixed this issue so that vanillacore doesn't return errors in this situation any longer.
2. I added a test to check this situation.  