### PR TITLE
A series of optimization for buffer & index

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,5 @@ VanillaCore is written by:
   Ching Tsai <ctsai@datalab.cs.nthu.edu.tw>
   Tz-Yu Lin <tylin@datalab.cs.nthu.edu.tw>
   Yun-Sheng Chang <yschang@datalab.cs.nthu.edu.tw>
+  Pin-Yu Wang <pywang@datalab.cs.nthu.edu.tw>
+  Yu-Xuan Lin <yxlin@datalab.cs.nthu.edu.tw>

--- a/src/main/java/org/vanilladb/core/storage/buffer/Buffer.java
+++ b/src/main/java/org/vanilladb/core/storage/buffer/Buffer.java
@@ -161,7 +161,11 @@ public class Buffer {
 	}
 
 	/**
-	 * Returns a block ID refers to the disk block that the buffer is pinned to.
+	 * Returns a block ID refers to the disk block that the buffer is pinned to. <br><br>
+	 * 
+	 * <b>Warning:</b><br>
+	 * Always make sure to pin the buffer first, then get buff.block().<br>
+	 * Or you may get an unexpected block.
 	 * 
 	 * @return a block ID
 	 */

--- a/src/main/java/org/vanilladb/core/storage/buffer/Buffer.java
+++ b/src/main/java/org/vanilladb/core/storage/buffer/Buffer.java
@@ -16,6 +16,7 @@
 package org.vanilladb.core.storage.buffer;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -49,7 +50,7 @@ public class Buffer {
 	
 	private Page contents = new Page();
 	private BlockId blk = null;
-	private int pins = 0;
+	private AtomicInteger pins = new AtomicInteger(0);
 	private AtomicBoolean isRecentlyPinned = new AtomicBoolean(false);
 	private boolean isNew = false;
 	private boolean isModified = false;
@@ -57,8 +58,8 @@ public class Buffer {
 	private LogSeqNum lastLsn = LogSeqNum.DEFAULT_VALUE;
 	
 	// Locks
-	private final ReadWriteLock internalLock = new ReentrantReadWriteLock();
-	private final Lock externalLock = new ReentrantLock();
+	private final ReadWriteLock contentLock = new ReentrantReadWriteLock();
+	private final Lock swapLock = new ReentrantLock();
 	private final Lock flushLock = new ReentrantLock();
 	
 	/**
@@ -85,26 +86,26 @@ public class Buffer {
 	 * @return the constant value at that offset
 	 */
 	public Constant getVal(int offset, Type type) {
-		internalLock.readLock().lock();
+		contentLock.readLock().lock();
 		try {
 			if (offset < 0 || offset >= BUFFER_SIZE)
 				throw new IndexOutOfBoundsException("" + offset);
 				
 			return contents.getVal(DATA_START_OFFSET + offset, type);
 		} finally {
-			internalLock.readLock().unlock();
+			contentLock.readLock().unlock();
 		}
 	}
 	
 	void setVal(int offset, Constant val) {
-		internalLock.writeLock().lock();
+		contentLock.writeLock().lock();
 		try {
 			if (offset < 0 || offset >= BUFFER_SIZE)
 				throw new IndexOutOfBoundsException("" + offset);
 			
 			contents.setVal(DATA_START_OFFSET + offset, val);
 		} finally {
-			internalLock.writeLock().unlock();
+			contentLock.writeLock().unlock();
 		}
 	}
 
@@ -125,7 +126,7 @@ public class Buffer {
 	 *            the LSN of the corresponding log record
 	 */
 	public void setVal(int offset, Constant val, long txNum, LogSeqNum lsn) {
-		internalLock.writeLock().lock();
+		contentLock.writeLock().lock();
 		try {
 			if (offset < 0 || offset >= BUFFER_SIZE)
 				throw new IndexOutOfBoundsException("" + offset);
@@ -138,7 +139,7 @@ public class Buffer {
 			lastLsn.writeToPage(contents, LAST_LSN_OFFSET);
 			contents.setVal(DATA_START_OFFSET + offset, val);
 		} finally {
-			internalLock.writeLock().unlock();
+			contentLock.writeLock().unlock();
 		}
 	}
 	
@@ -150,11 +151,12 @@ public class Buffer {
 	 * @return the LSN of the latest affected log record
 	 */
 	public LogSeqNum lastLsn(){
-		internalLock.readLock().lock();
+		// Use contentLock because lastLsn will be modified from setVal.
+		contentLock.readLock().lock();
 		try {
 			return lastLsn;
 		} finally {
-			internalLock.readLock().unlock();
+			contentLock.readLock().unlock();
 		}
 	}
 
@@ -164,12 +166,9 @@ public class Buffer {
 	 * @return a block ID
 	 */
 	public BlockId block() {
-		internalLock.readLock().lock();
-		try {
-			return blk;
-		} finally {
-			internalLock.readLock().unlock();
-		}
+		// Optimization
+		// blk will be modified only if no txs pin this buffer 
+		return blk;
 	}
 	
 	/**
@@ -194,16 +193,16 @@ public class Buffer {
 		flushLock.unlock();
 	}
 	
-	protected Lock getExternalLock() {
-		return externalLock;
+	protected Lock getSwapLock() {
+		return swapLock;
 	}
 
 	protected void close() {
-		internalLock.writeLock().lock();
+		contentLock.writeLock().lock();
 		try {
 			contents.close();
 		} finally {
-			internalLock.writeLock().unlock();
+			contentLock.writeLock().unlock();
 		}
 	}
 
@@ -213,7 +212,7 @@ public class Buffer {
 	 * to writing the page to disk.
 	 */
 	void flush() {
-		internalLock.writeLock().lock();
+		contentLock.writeLock().lock();
 		flushLock.lock();
 		try {
 			if (isNew || isModified) {
@@ -224,7 +223,7 @@ public class Buffer {
 			}
 		} finally {
 			flushLock.unlock();
-			internalLock.writeLock().unlock();
+			contentLock.writeLock().unlock();
 		}
 	}
 
@@ -232,25 +231,21 @@ public class Buffer {
 	 * Increases the buffer's pin count.
 	 */
 	void pin() {
-		internalLock.writeLock().lock();
-		try {
-			pins++;
-			isRecentlyPinned.set(true);
-		} finally {
-			internalLock.writeLock().unlock();
-		}
+		// Optimization: This might be a danger optimization
+		// We have to make sure that txs have acquired swapLock before pin(),
+		// so that no two txs can call pin at the same time.
+		pins.incrementAndGet();
+		isRecentlyPinned.set(true);
 	}
 
 	/**
 	 * Decreases the buffer's pin count.
 	 */
 	void unpin() {
-		internalLock.writeLock().lock();
-		try {
-			pins--;
-		} finally {
-			internalLock.writeLock().unlock();
-		}
+		// Optimization: This might be a danger optimization
+		// We have to make sure that txs have acquired swapLock before unpin(),
+		// so that no two txs can call unpin at the same time.
+		pins.decrementAndGet();
 	}
 
 	/**
@@ -260,12 +255,10 @@ public class Buffer {
 	 * @return true if the buffer is pinned
 	 */
 	boolean isPinned() {
-		internalLock.readLock().lock();
-		try {
-			return pins > 0;
-		} finally {
-			internalLock.readLock().unlock();
-		}
+		// Optimization: This might be a danger optimization
+		// We have to make sure that txs have acquired swapLock before isPinned(),
+		// so that no two txs can call isPinned at the same time.
+		return pins.get() > 0;
 	}
 	
 	boolean checkRecentlyPinnedAndReset() {
@@ -277,12 +270,13 @@ public class Buffer {
 	 * 
 	 * @return true if the buffer is dirty
 	 */
+	@Deprecated
 	boolean isModified() {
-		internalLock.writeLock().lock();
+		contentLock.writeLock().lock();
 		try {
 			return isModified;
 		} finally {
-			internalLock.writeLock().unlock();
+			contentLock.writeLock().unlock();
 		}
 	}
 
@@ -295,16 +289,14 @@ public class Buffer {
 	 *            a block ID
 	 */
 	void assignToBlock(BlockId blk) {
-		internalLock.writeLock().lock();
-		try {
-			flush();
-			this.blk = blk;
-			contents.read(blk);
-			pins = 0;
-			lastLsn = LogSeqNum.readFromPage(contents, LAST_LSN_OFFSET);
-		} finally {
-			internalLock.writeLock().unlock();
-		}
+		// Optimization: This might be a danger optimization
+		// This method is called because no tx pin this buffer,
+		// which means no tx will modify or read the content.
+		flush();
+		this.blk = blk;
+		contents.read(blk);
+		pins = new AtomicInteger(0);
+		lastLsn = LogSeqNum.readFromPage(contents, LAST_LSN_OFFSET);
 	}
 
 	/**
@@ -318,17 +310,15 @@ public class Buffer {
 	 *            a page formatter, used to initialize the page
 	 */
 	void assignToNew(String fileName, PageFormatter fmtr) {
-		internalLock.writeLock().lock();
-		try {
-			flush();
-			fmtr.format(this);
-			blk = contents.append(fileName);
-			pins = 0;
-			isNew = true;
-			lastLsn = LogSeqNum.DEFAULT_VALUE;
-		} finally {
-			internalLock.writeLock().unlock();
-		}
+		// Optimization: This might be a danger optimization
+		// This method is called because no tx pin this buffer,
+		// which means no tx will modify or read the content.
+		flush();
+		fmtr.format(this);
+		blk = contents.append(fileName);
+		pins = new AtomicInteger(0);
+		isNew = true;
+		lastLsn = LogSeqNum.DEFAULT_VALUE;
 	}
 	
 	/**

--- a/src/main/java/org/vanilladb/core/storage/buffer/Buffer.java
+++ b/src/main/java/org/vanilladb/core/storage/buffer/Buffer.java
@@ -302,7 +302,7 @@ public class Buffer {
 		flush();
 		this.blk = blk;
 		contents.read(blk);
-		pins = new AtomicInteger(0);
+		pins.set(0);
 		lastLsn = LogSeqNum.readFromPage(contents, LAST_LSN_OFFSET);
 	}
 
@@ -327,7 +327,7 @@ public class Buffer {
 		flush();
 		fmtr.format(this);
 		blk = contents.append(fileName);
-		pins = new AtomicInteger(0);
+		pins.set(0);
 		isNew = true;
 		lastLsn = LogSeqNum.DEFAULT_VALUE;
 	}

--- a/src/main/java/org/vanilladb/core/storage/buffer/Buffer.java
+++ b/src/main/java/org/vanilladb/core/storage/buffer/Buffer.java
@@ -292,7 +292,6 @@ public class Buffer {
 		// Optimization: This might be a danger optimization
 		// This method is called because no tx pin this buffer,
 		// which means no tx will modify or read the content.
-	
 		if (pins.get() > 0) {
 			throw new RuntimeException("The buffer is pinned by other transactions");
 		}
@@ -318,6 +317,10 @@ public class Buffer {
 		// Optimization: This might be a danger optimization
 		// This method is called because no tx pin this buffer,
 		// which means no tx will modify or read the content.
+		if (pins.get() > 0) {
+			throw new RuntimeException("The buffer is pinned by other transactions");
+		}
+		
 		flush();
 		fmtr.format(this);
 		blk = contents.append(fileName);

--- a/src/main/java/org/vanilladb/core/storage/buffer/Buffer.java
+++ b/src/main/java/org/vanilladb/core/storage/buffer/Buffer.java
@@ -164,7 +164,7 @@ public class Buffer {
 	 * Returns a block ID refers to the disk block that the buffer is pinned to. <br><br>
 	 * 
 	 * <b>Warning:</b><br>
-	 * Always make sure to pin the buffer first, then get buff.block().<br>
+	 * Always make sure to get buff.block() before unpin.<br>
 	 * Or you may get an unexpected block.
 	 * 
 	 * @return a block ID

--- a/src/main/java/org/vanilladb/core/storage/buffer/Buffer.java
+++ b/src/main/java/org/vanilladb/core/storage/buffer/Buffer.java
@@ -274,7 +274,6 @@ public class Buffer {
 	 * 
 	 * @return true if the buffer is dirty
 	 */
-	@Deprecated
 	boolean isModified() {
 		contentLock.writeLock().lock();
 		try {

--- a/src/main/java/org/vanilladb/core/storage/buffer/Buffer.java
+++ b/src/main/java/org/vanilladb/core/storage/buffer/Buffer.java
@@ -292,6 +292,11 @@ public class Buffer {
 		// Optimization: This might be a danger optimization
 		// This method is called because no tx pin this buffer,
 		// which means no tx will modify or read the content.
+	
+		if (pins.get() > 0) {
+			throw new RuntimeException("The buffer is pinned by other transactions");
+		}
+		
 		flush();
 		this.blk = blk;
 		contents.read(blk);

--- a/src/main/java/org/vanilladb/core/storage/buffer/BufferPoolMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/buffer/BufferPoolMgr.java
@@ -80,11 +80,10 @@ class BufferPoolMgr {
 	}
 	
 	private Boolean isIndexRootBuffer(Buffer buff) {
-		BlockId tempBlock = buff.block();
-		return tempBlock != null &&
-			tempBlock.fileName().contains(".idx") &&
-			tempBlock.number() == 0;
-				
+		BlockId blk = buff.block();
+		return blk != null &&
+			blk.fileName().contains(".idx") &&
+			blk.number() == 0;	
 	}
 
 	/**

--- a/src/main/java/org/vanilladb/core/storage/buffer/BufferPoolMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/buffer/BufferPoolMgr.java
@@ -241,9 +241,6 @@ class BufferPoolMgr {
 	}
 
 	private Buffer findExistingBuffer(BlockId blk) {
-		Buffer buff = blockMap.get(blk);
-		if (buff != null && buff.block().equals(blk))
-			return buff;
-		return null;
+		return blockMap.get(blk);
 	}
 }

--- a/src/main/java/org/vanilladb/core/storage/buffer/BufferPoolMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/buffer/BufferPoolMgr.java
@@ -92,7 +92,7 @@ class BufferPoolMgr {
 	 */
 	void flushAll() {
 		for (Buffer buff : bufferPool) {
-			// Optimization: skip getting external lock of index root buffer
+			// Optimization: skip getting swapLock of index root buffer
 			// because index root buffer won't be swapped
 			if (isIndexRootBuffer(buff)) {
 				buff.flush();
@@ -170,7 +170,7 @@ class BufferPoolMgr {
 			// If it exists
 			} else {
 				// Optimization:
-				// index root buffers won't be swapped
+				// Index root buffers won't be swapped
 				// therefore, pin and unpin is unnecessary
 				if (isIndexRootBuffer(buff)) {
 					return buff;

--- a/src/main/java/org/vanilladb/core/storage/buffer/BufferPoolMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/buffer/BufferPoolMgr.java
@@ -34,7 +34,7 @@ class BufferPoolMgr {
 	private AtomicInteger numAvailable;
 
 	// Optimization: Lock striping
-	private int stripSize = 1009;
+	private static final int stripSize = 1009;
 	private Object[] anchors = new Object[stripSize];
 	private ReentrantLock[] xSwapLocks = new ReentrantLock[stripSize];
 

--- a/src/main/java/org/vanilladb/core/storage/buffer/BufferPoolMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/buffer/BufferPoolMgr.java
@@ -85,10 +85,10 @@ class BufferPoolMgr {
 	void flushAll() {
 		for (Buffer buff : bufferPool) {
 			try {
-				buff.getExternalLock().lock();
+				buff.getSwapLock().lock();
 				buff.flush();
 			} finally {
-				buff.getExternalLock().unlock();
+				buff.getSwapLock().unlock();
 			}
 		}
 	}
@@ -123,7 +123,7 @@ class BufferPoolMgr {
 					buff = bufferPool[currBlk];
 					
 					// Get the lock of buffer if it is free
-					if (buff.getExternalLock().tryLock()) {
+					if (buff.getSwapLock().tryLock()) {
 						try {
 							// Check if there is no one use it
 							if (!buff.isPinned() && !buff.checkRecentlyPinnedAndReset()) {
@@ -144,7 +144,7 @@ class BufferPoolMgr {
 							}
 						} finally {
 							// Release the lock of buffer
-							buff.getExternalLock().unlock();
+							buff.getSwapLock().unlock();
 						}
 					}
 					currBlk = (currBlk + 1) % bufferPool.length;
@@ -154,7 +154,7 @@ class BufferPoolMgr {
 			// If it exists
 			} else {
 				// Get the lock of buffer
-				buff.getExternalLock().lock();
+				buff.getSwapLock().lock();
 				
 				// Optimization
 				// Early release the xSwapLock
@@ -173,7 +173,7 @@ class BufferPoolMgr {
 					
 				} finally {
 					// Release the lock of buffer
-					buff.getExternalLock().unlock();
+					buff.getSwapLock().unlock();
 				}
 			}
 		} finally {
@@ -207,7 +207,7 @@ class BufferPoolMgr {
 				Buffer buff = bufferPool[currBlk];
 				
 				// Get the lock of buffer if it is free
-				if (buff.getExternalLock().tryLock()) {
+				if (buff.getSwapLock().tryLock()) {
 					try {
 						if (!buff.isPinned() && !buff.checkRecentlyPinnedAndReset()) {
 							this.lastReplacedBuff = currBlk;
@@ -227,7 +227,7 @@ class BufferPoolMgr {
 						}
 					} finally {
 						// Release the lock of buffer
-						buff.getExternalLock().unlock();
+						buff.getSwapLock().unlock();
 					}
 				}
 				currBlk = (currBlk + 1) % bufferPool.length;
@@ -246,13 +246,13 @@ class BufferPoolMgr {
 		for (Buffer buff : buffs) {
 			try {
 				// Get the lock of buffer
-				buff.getExternalLock().lock();
+				buff.getSwapLock().lock();
 				buff.unpin();
 				if (!buff.isPinned())
 					numAvailable.incrementAndGet();
 			} finally {
 				// Release the lock of buffer
-				buff.getExternalLock().unlock();
+				buff.getSwapLock().unlock();
 			}
 		}
 	}

--- a/src/main/java/org/vanilladb/core/storage/file/FileMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/file/FileMgr.java
@@ -251,8 +251,6 @@ public class FileMgr {
 		return !fileNotEmptyCache.get(fileName);
 	}
 	
-	
-
 	/**
 	 * Returns a boolean indicating whether the file manager had to create a new
 	 * database directory.

--- a/src/main/java/org/vanilladb/core/storage/index/btree/BTreeIndex.java
+++ b/src/main/java/org/vanilladb/core/storage/index/btree/BTreeIndex.java
@@ -204,7 +204,7 @@ public class BTreeIndex extends Index {
 	/**
 	 * Deletes the specified index record. The method first traverses the
 	 * directory to find the leaf page containing that record; then it deletes
-	 * the record from the page. F
+	 * the record from the page.
 	 * 
 	 * @see Index#delete(SearchKey, RecordId, boolean)
 	 */

--- a/src/main/java/org/vanilladb/core/storage/index/btree/BTreeIndex.java
+++ b/src/main/java/org/vanilladb/core/storage/index/btree/BTreeIndex.java
@@ -35,10 +35,7 @@ import org.vanilladb.core.storage.tx.concurrency.ConcurrencyMgr;
  * A B-tree implementation of {@link Index}.
  */
 public class BTreeIndex extends Index {
-	
 	protected static enum SearchPurpose { READ, INSERT, DELETE };
-	private static ConcurrentHashMap<String, Boolean> fileEmptyCache = new ConcurrentHashMap<String, Boolean>();
-	
 	private ConcurrencyMgr ccMgr;
 	private String leafFileName, dirFileName;
 	private BTreeLeaf leaf = null;
@@ -260,14 +257,9 @@ public class BTreeIndex extends Index {
 		// Optimization
 		// Assume we won't delete the BtreeIndex.
 		// Once the index file is not empty, the file won't be empty again
+		ccMgr.readFile(fileName);
+		return VanillaDb.fileMgr().isFileEmpty(fileName);
 		
-		boolean cacheMiss = fileEmptyCache.get(fileName) == null;
-		// Call fileSize(fileName) again, if cache miss or the cache says the file is empty.
-		if (cacheMiss || fileEmptyCache.get(fileName)) {
-			fileEmptyCache.put(fileName, fileSize(fileName) == 0);
-		}
-		
-		return fileEmptyCache.get(fileName);
 	}
 	
 	private long fileSize(String fileName) {
@@ -275,6 +267,7 @@ public class BTreeIndex extends Index {
 		return VanillaDb.fileMgr().size(fileName);
 	}
 
+	
 	private BlockId appendBlock(String fileName, Schema sch, long[] flags) {
 		ccMgr.modifyFile(fileName);
 		BTPageFormatter btpf = new BTPageFormatter(sch, flags);

--- a/src/main/java/org/vanilladb/core/storage/index/btree/BTreeIndex.java
+++ b/src/main/java/org/vanilladb/core/storage/index/btree/BTreeIndex.java
@@ -16,7 +16,6 @@
 package org.vanilladb.core.storage.index.btree;
 
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.vanilladb.core.server.VanillaDb;
 import org.vanilladb.core.sql.Schema;
@@ -266,7 +265,6 @@ public class BTreeIndex extends Index {
 		ccMgr.readFile(fileName);
 		return VanillaDb.fileMgr().size(fileName);
 	}
-
 	
 	private BlockId appendBlock(String fileName, Schema sch, long[] flags) {
 		ccMgr.modifyFile(fileName);

--- a/src/main/java/org/vanilladb/core/storage/index/btree/BTreeIndex.java
+++ b/src/main/java/org/vanilladb/core/storage/index/btree/BTreeIndex.java
@@ -273,8 +273,10 @@ public class BTreeIndex extends Index {
 		BTPageFormatter btpf = new BTPageFormatter(sch, flags);
 
 		Buffer buff = tx.bufferMgr().pinNew(fileName, btpf);
+		// Danger!
+		// Must get block before unpin
+		BlockId blk = buff.block();
 		tx.bufferMgr().unpin(buff);
-
-		return buff.block();
+		return blk;
 	}
 }

--- a/src/main/java/org/vanilladb/core/storage/index/btree/BTreePage.java
+++ b/src/main/java/org/vanilladb/core/storage/index/btree/BTreePage.java
@@ -453,8 +453,12 @@ public class BTreePage {
 		tx.concurrencyMgr().modifyFile(blk.fileName());
 		BTPageFormatter btpf = new BTPageFormatter(schema, flags);
 		Buffer buff = tx.bufferMgr().pinNew(blk.fileName(), btpf);
+		
+		// Danger!
+		// Must get block before unpin
+		BlockId blk = buff.block();
 		tx.bufferMgr().unpin(buff);
-		return buff.block();
+		return blk;
 	}
 	
 	private void setValUnchecked(int slot, String fldName, Constant val) {

--- a/src/main/java/org/vanilladb/core/storage/record/RecordFile.java
+++ b/src/main/java/org/vanilladb/core/storage/record/RecordFile.java
@@ -378,10 +378,11 @@ public class RecordFile implements Record {
 			tx.concurrencyMgr().modifyFile(fileName);
 		RecordFormatter fmtr = new RecordFormatter(ti);
 		Buffer buff = tx.bufferMgr().pinNew(fileName, fmtr);
-		tx.bufferMgr().unpin(buff);
+		// Danger!
+		// Must get block before unpin
 		if (!isTempTable())
 			tx.concurrencyMgr().insertBlock(buff.block());
-
+		tx.bufferMgr().unpin(buff);	
 	}
 
 	private FileHeaderPage openHeaderForModification() {

--- a/src/test/java/org/vanilladb/core/storage/file/FileTest.java
+++ b/src/test/java/org/vanilladb/core/storage/file/FileTest.java
@@ -236,7 +236,7 @@ public class FileTest {
 		p1.setVal(INT_SIZE, TEST_INT_456);
 		p1.write(blk);
 		
-		// fm.isFileEmpty should cache that file is no longer empty
+		// fm.isFileEmpty should cache because file is no longer empty
 		assertFalse(
 				"*****FileTest: the file is no longer empty, cache implementation might be wrong",
 				fm.isFileEmpty(filename));

--- a/src/test/java/org/vanilladb/core/storage/file/FileTest.java
+++ b/src/test/java/org/vanilladb/core/storage/file/FileTest.java
@@ -17,6 +17,7 @@ package org.vanilladb.core.storage.file;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 import static org.vanilladb.core.sql.Type.INTEGER;
 import static org.vanilladb.core.sql.Type.VARCHAR;
@@ -214,4 +215,35 @@ public class FileTest {
 		BlockId b = new BlockId(b1.fileName(), b1.number());
 		assertTrue("*****FileTest: bad block extraction", b.equals(b1));
 	}
-}
+	
+	@Test
+	public void testIsFileEmpty() {
+		String filename = FileMgr.TMP_FILE_NAME_PREFIX + "_test_file_empty_cache";
+
+		// fm.isFileEmpty won't use cache at the first time 
+		assertTrue(
+				"*****FileTest: the file should be empty",
+				fm.isFileEmpty(filename));
+		
+		// fm.isFileEmpty won't use cache because the file is still empty
+		assertTrue(
+				"*****FileTest: the file should be empty, cache implementation might be wrong",
+				fm.isFileEmpty(filename));
+		
+		// write 123 and 456 at block 0
+		BlockId blk = new BlockId(filename, 0);
+		p1.setVal(0, TEST_INT_123);
+		p1.setVal(INT_SIZE, TEST_INT_456);
+		p1.write(blk);
+		
+		// fm.isFileEmpty should cache that file is no longer empty
+		assertFalse(
+				"*****FileTest: the file is no longer empty, cache implementation might be wrong",
+				fm.isFileEmpty(filename));
+	
+		// fm.isFileEmpty use cache completely
+		assertFalse(
+				"*****FileTest: the file is no longer empty, cache implementation might be wrong",
+				fm.isFileEmpty(filename));
+	}
+ }


### PR DESCRIPTION
Basically, each commit is corresponding to an optimization or a revision.

1. I cache whether the index file size is non-empty.
2. I reduce a redundant call of getting blockId.
3. I change the synchronized block in bufferPoolMgr.pin() to reentrant lock, and shrink the critical section.
4. I rename "Buffer.externalLock" to "Buffer.swapLock".
5. I remove some locks in Buffer, because the swap lock has guarantees the concurrent correctness.
6. I persist index-root buffer in BufferPoolMgr, which means that buffer won't be swapped.

-------------------------------------------------------------------------------------------------------
Here are what we need to check

a. Is it safe to remove lock for Buffer.blockId?