### PR TITLE
Reduce the call of synchronized block in BufferMgr.unpin

### DIFF
--- a/src/main/java/org/vanilladb/core/storage/buffer/BufferMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/buffer/BufferMgr.java
@@ -161,7 +161,7 @@ public class BufferMgr implements TransactionLifecycleListener {
 			}
 
 			// Optimization: A tx, which have waited once to pin a buffer,
-			// is responsible for notifying other waiting txs.g
+			// is responsible for notifying other waiting txs.
 			if (waitOnce) {
 				synchronized (bufferPool) {
 					bufferPool.notifyAll();

--- a/src/main/java/org/vanilladb/core/storage/buffer/BufferMgr.java
+++ b/src/main/java/org/vanilladb/core/storage/buffer/BufferMgr.java
@@ -62,7 +62,6 @@ public class BufferMgr implements TransactionLifecycleListener {
 		EPSILON = CoreProperties.getLoader().getPropertyAsLong(BufferMgr.class.getName() + ".EPSILON", 50);
 		BUFFER_POOL_SIZE = CoreProperties.getLoader()
 				.getPropertyAsInteger(BufferMgr.class.getName() + ".BUFFER_POOL_SIZE", 1024);
-		System.out.println("BufferMgr unpin opt========================================================");
 	}
 
 	class PinningBuffer {


### PR DESCRIPTION
This optimization provides 2% performance improvement.
I reduce the access of a critical section in BufferMgr.unpin.