### PR TITLE
Fixed typo: getStroredProcedure -> getStoredProcedure

### DIFF
--- a/src/main/java/org/vanilladb/core/remote/storedprocedure/RemoteConnectionImpl.java
+++ b/src/main/java/org/vanilladb/core/remote/storedprocedure/RemoteConnectionImpl.java
@@ -42,7 +42,7 @@ class RemoteConnectionImpl extends UnicastRemoteObject implements
 	public SpResultSet callStoredProc(int pid, Object... pars)
 			throws RemoteException {
 		try {
-			StoredProcedure<?> sp = VanillaDb.spFactory().getStroredProcedure(pid);
+			StoredProcedure<?> sp = VanillaDb.spFactory().getStoredProcedure(pid);
 			sp.prepare(pars);
 			return sp.execute();
 		} catch (Exception e) {

--- a/src/main/java/org/vanilladb/core/sql/storedprocedure/SampleStoredProcedureFactory.java
+++ b/src/main/java/org/vanilladb/core/sql/storedprocedure/SampleStoredProcedureFactory.java
@@ -18,7 +18,7 @@ package org.vanilladb.core.sql.storedprocedure;
 public class SampleStoredProcedureFactory implements StoredProcedureFactory {
 
 	@Override
-	public StoredProcedure<?> getStroredProcedure(int pid) {
+	public StoredProcedure<?> getStoredProcedure(int pid) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/src/main/java/org/vanilladb/core/sql/storedprocedure/StoredProcedureFactory.java
+++ b/src/main/java/org/vanilladb/core/sql/storedprocedure/StoredProcedureFactory.java
@@ -17,6 +17,6 @@ package org.vanilladb.core.sql.storedprocedure;
 
 public interface StoredProcedureFactory {
 	
-	StoredProcedure<?> getStroredProcedure(int pid);
+	StoredProcedure<?> getStoredProcedure(int pid);
 	
 }


### PR DESCRIPTION
Fixed typo: StoredProcedureFactory.getStroredProcedure -> StoredProcedureFactory.getStoredProcedure (all three occurrences in the codebase)