### PR TITLE
Fix bug in LockTable

### DIFF
--- a/src/main/java/org/vanilladb/core/storage/tx/concurrency/LockTable.java
+++ b/src/main/java/org/vanilladb/core/storage/tx/concurrency/LockTable.java
@@ -95,7 +95,7 @@ class LockTable {
 		}
 	}
 
-	private Map<Object, Lockers> lockerMap = new HashMap<Object, Lockers>();
+	private Map<Object, Lockers> lockerMap = new ConcurrentHashMap<>();
 	private Map<Long, Set<Object>> lockByMap = new ConcurrentHashMap<Long, Set<Object>>();
 	private Set<Long> txnsToBeAborted = Collections.synchronizedSet(new HashSet<Long>());
 	private Map<Long, Object> txWaitMap = new ConcurrentHashMap<Long, Object>();


### PR DESCRIPTION
1. `lockerMap` should be a `ConcurrentHashMap` since it can be accessed by multiple threads.
2.  When a transaction already has the lock for `obj` or `LockAbortException` is thrown, `txNum` stays in `txWaitMap` and never removed.   