### PR TITLE
Fix bug in MultiBufferProductScan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+### IntelliJ ###
+.idea/
 
 ### Eclipse ###
 .settings/

--- a/src/main/java/org/vanilladb/core/query/algebra/multibuffer/MultiBufferProductScan.java
+++ b/src/main/java/org/vanilladb/core/query/algebra/multibuffer/MultiBufferProductScan.java
@@ -59,7 +59,7 @@ public class MultiBufferProductScan implements Scan {
 	 */
 	@Override
 	public void beforeFirst() {
-		nextBlkNum = 0;
+		nextBlkNum = 1; // Record page starts from page 1 since page 0 is reserved for file header
 		useNextChunk();
 	}
 

--- a/src/test/java/org/vanilladb/core/query/planner/BasicQueryPlannerTest.java
+++ b/src/test/java/org/vanilladb/core/query/planner/BasicQueryPlannerTest.java
@@ -15,9 +15,7 @@
  *******************************************************************************/
 package org.vanilladb.core.query.planner;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.sql.Connection;
 import java.util.logging.Level;


### PR DESCRIPTION
Fix a bug in `MultiBufferProductScan` where record searching in temp table starts at block 0 that is reserved for the header page #101 