### PR TITLE
Fix NoSuchMethodError in JavaNioByteBuffer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.release>8</maven.compiler.release>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
In short, the error is caused by Maven defaulting to newer Java version when compiling. 
As a result, the build artifact is not compatible with Java 8.

For more details on what's wrong, refer to 

> https://www.morling.dev/blog/bytebuffer-and-the-dreaded-nosuchmethoderror/